### PR TITLE
Implement automatic table of contents generation

### DIFF
--- a/src/hyperdoc.zig
+++ b/src/hyperdoc.zig
@@ -16,6 +16,7 @@ pub const Document = struct {
     contents: []Block,
     content_ids: []?Reference,
     id_map: std.StringArrayHashMapUnmanaged(usize), // id -> index
+    toc: TableOfContents,
 
     // header information
     lang: LanguageTag = .inherit, // inherit here means "unset"
@@ -23,6 +24,12 @@ pub const Document = struct {
     author: ?[]const u8,
     date: ?DateTime,
     timezone: ?TimeZoneOffset,
+
+    pub const TableOfContents = struct {
+        level: Block.HeadingLevel,
+        headings: []usize,
+        children: []TableOfContents,
+    };
 
     pub fn deinit(doc: *Document) void {
         doc.arena.deinit();
@@ -553,12 +560,16 @@ pub fn parse(
     try sema.validate_references(&id_map);
 
     const doc_lang = header.lang orelse LanguageTag.inherit;
+    const contents = try sema.blocks.toOwnedSlice(arena.allocator());
+    const block_locations = try sema.block_locations.toOwnedSlice(arena.allocator());
+    const toc = try sema.build_toc(contents, block_locations);
 
     return .{
         .arena = arena,
-        .contents = try sema.blocks.toOwnedSlice(arena.allocator()),
+        .contents = contents,
         .content_ids = content_ids,
         .id_map = id_map,
+        .toc = toc,
 
         .lang = doc_lang,
         .title = header.title,
@@ -674,12 +685,27 @@ pub const SemanticAnalyzer = struct {
         location: Parser.Location,
     };
 
+    const TocBuilder = struct {
+        level: Block.HeadingLevel,
+        headings: std.ArrayList(usize),
+        children: std.ArrayList(*TocBuilder),
+
+        fn init(level: Block.HeadingLevel) @This() {
+            return .{
+                .level = level,
+                .headings = .empty,
+                .children = .empty,
+            };
+        }
+    };
+
     arena: std.mem.Allocator,
     diagnostics: ?*Diagnostics,
     code: []const u8,
 
     header: ?Header = null,
     blocks: std.ArrayList(Block) = .empty,
+    block_locations: std.ArrayList(Parser.Location) = .empty,
     ids: std.ArrayList(?Reference) = .empty,
     id_locations: std.ArrayList(?Parser.Location) = .empty,
     pending_refs: std.ArrayList(RefUse) = .empty,
@@ -734,6 +760,7 @@ pub const SemanticAnalyzer = struct {
                     null;
 
                 try sema.blocks.append(sema.arena, block);
+                try sema.block_locations.append(sema.arena, node.location);
                 try sema.ids.append(sema.arena, id);
                 try sema.id_locations.append(sema.arena, id_location);
             },
@@ -1871,6 +1898,102 @@ pub const SemanticAnalyzer = struct {
         }
     }
 
+    fn build_toc(sema: *SemanticAnalyzer, contents: []const Block, block_locations: []const Parser.Location) !Document.TableOfContents {
+        std.debug.assert(contents.len == block_locations.len);
+
+        var root_builder = TocBuilder.init(.h1);
+        defer root_builder.headings.deinit(sema.arena);
+        defer root_builder.children.deinit(sema.arena);
+
+        var stack: std.ArrayList(*TocBuilder) = .empty;
+        defer stack.deinit(sema.arena);
+
+        try stack.append(sema.arena, &root_builder);
+
+        for (contents, 0..) |block, block_index| {
+            const heading = switch (block) {
+                .heading => |value| value,
+                else => continue,
+            };
+
+            const target_depth = heading_level_index(heading.level);
+
+            while (stack.items.len > target_depth) {
+                _ = stack.pop();
+            }
+
+            while (stack.items.len < target_depth) {
+                const parent = stack.items[stack.items.len - 1];
+                try sema.append_toc_entry(&stack, parent, block_index, block_locations, .automatic);
+            }
+
+            const parent = stack.items[stack.items.len - 1];
+            try sema.append_toc_entry(&stack, parent, block_index, block_locations, .real);
+        }
+
+        return sema.materialize_toc(&root_builder);
+    }
+
+    fn append_toc_entry(
+        sema: *SemanticAnalyzer,
+        stack: *std.ArrayList(*TocBuilder),
+        parent: *TocBuilder,
+        heading_index: usize,
+        block_locations: []const Parser.Location,
+        kind: enum { automatic, real },
+    ) !void {
+        if (kind == .automatic) {
+            const heading_location = block_locations[heading_index];
+            try sema.emit_diagnostic(
+                .{ .automatic_heading_insertion = .{ .level = parent.level } },
+                heading_location,
+            );
+        }
+
+        try parent.headings.append(sema.arena, heading_index);
+
+        const child_level = next_heading_level(parent.level);
+        if (child_level == parent.level) {
+            return;
+        }
+
+        const child = try sema.arena.create(TocBuilder);
+        child.* = TocBuilder.init(child_level);
+
+        try parent.children.append(sema.arena, child);
+        try stack.append(sema.arena, child);
+    }
+
+    fn materialize_toc(sema: *SemanticAnalyzer, builder: *TocBuilder) !Document.TableOfContents {
+        var node: Document.TableOfContents = .{
+            .level = builder.level,
+            .headings = try builder.headings.toOwnedSlice(sema.arena),
+            .children = try sema.arena.alloc(Document.TableOfContents, builder.children.items.len),
+        };
+
+        for (builder.children.items, 0..) |child_builder, index| {
+            node.children[index] = try sema.materialize_toc(child_builder);
+        }
+
+        return node;
+    }
+
+    fn heading_level_index(level: Block.HeadingLevel) usize {
+        return switch (level) {
+            .h1 => 1,
+            .h2 => 2,
+            .h3 => 3,
+        };
+    }
+
+    fn next_heading_level(level: Block.HeadingLevel) Block.HeadingLevel {
+        return switch (level) {
+            .h1 => .h2,
+            .h2 => .h3,
+            .h3 => .h3,
+        };
+    }
+
     fn emit_diagnostic(sema: *SemanticAnalyzer, code: Diagnostic.Code, location: Parser.Location) !void {
         if (sema.diagnostics) |diag| {
             try diag.add(code, sema.make_location(location.offset));
@@ -2808,6 +2931,7 @@ pub const Diagnostic = struct {
     pub const ForbiddenControlCharacter = struct { codepoint: u21 };
     pub const TableShapeError = struct { actual: usize, expected: usize };
     pub const ReferenceError = struct { ref: []const u8 };
+    pub const AutomaticHeading = struct { level: Block.HeadingLevel };
 
     pub const Code = union(enum) {
         // errors:
@@ -2856,6 +2980,7 @@ pub const Diagnostic = struct {
         redundant_inline: InlineUsageError,
         attribute_leading_trailing_whitespace,
         tab_character,
+        automatic_heading_insertion: AutomaticHeading,
 
         pub fn severity(code: Code) Severity {
             return switch (code) {
@@ -2904,6 +3029,7 @@ pub const Diagnostic = struct {
                 .attribute_leading_trailing_whitespace,
                 .tab_character,
                 .document_starts_with_bom,
+                .automatic_heading_insertion,
                 => .warning,
             };
         }
@@ -2979,6 +3105,8 @@ pub const Diagnostic = struct {
 
                 .missing_document_language => try w.writeAll("Document language is missing; set lang on the hdoc header."),
                 .tab_character => try w.writeAll("Tab character is not allowed; use spaces instead."),
+
+                .automatic_heading_insertion => |ctx| try w.print("Inserted automatic {t} to fill heading level gap.", .{ctx.level}),
             }
         }
     };

--- a/src/render/dump.zig
+++ b/src/render/dump.zig
@@ -259,6 +259,19 @@ fn dumpBlockListField(writer: *Writer, indent: usize, key: []const u8, blocks: [
     }
 }
 
+fn dumpNumberListField(writer: *Writer, indent: usize, key: []const u8, values: []const usize) Writer.Error!void {
+    try writeIndent(writer, indent);
+    if (values.len == 0) {
+        try writer.print("{s}: []\n", .{key});
+        return;
+    }
+    try writer.print("{s}:\n", .{key});
+    for (values) |value| {
+        try writeIndent(writer, indent + indent_step);
+        try writer.print("- {}\n", .{value});
+    }
+}
+
 fn dumpOptionalStringListField(writer: *Writer, indent: usize, key: []const u8, values: []?hdoc.Reference) Writer.Error!void {
     try writeIndent(writer, indent);
     if (values.len == 0) {
@@ -360,6 +373,32 @@ fn dumpTableRowsField(writer: *Writer, indent: usize, key: []const u8, rows: []c
     }
 }
 
+fn dumpTableOfContentsChildren(writer: *Writer, indent: usize, children: []const hdoc.Document.TableOfContents) Writer.Error!void {
+    try writeIndent(writer, indent);
+    if (children.len == 0) {
+        try writer.writeAll("children: []\n");
+        return;
+    }
+    try writer.writeAll("children:\n");
+    for (children) |child| {
+        try writeIndent(writer, indent + indent_step);
+        try writer.writeAll("-\n");
+        try dumpTableOfContentsNode(writer, indent + 2 * indent_step, child);
+    }
+}
+
+fn dumpTableOfContentsNode(writer: *Writer, indent: usize, toc: hdoc.Document.TableOfContents) Writer.Error!void {
+    try dumpEnumField(writer, indent, "level", toc.level);
+    try dumpNumberListField(writer, indent, "headings", toc.headings);
+    try dumpTableOfContentsChildren(writer, indent, toc.children);
+}
+
+fn dumpTableOfContents(writer: *Writer, indent: usize, toc: hdoc.Document.TableOfContents) Writer.Error!void {
+    try writeIndent(writer, indent);
+    try writer.writeAll("toc:\n");
+    try dumpTableOfContentsNode(writer, indent + indent_step, toc);
+}
+
 fn dumpBlockInline(writer: *Writer, indent: usize, block: hdoc.Block) Writer.Error!void {
     switch (block) {
         .heading => |heading| {
@@ -423,6 +462,7 @@ fn dumpDocument(writer: *Writer, doc: *const hdoc.Document) Writer.Error!void {
     try dumpOptionalStringField(writer, indent_step, "title", doc.title);
     try dumpOptionalStringField(writer, indent_step, "author", doc.author);
     try dumpOptionalDateTimeField(writer, indent_step, "date", doc.date);
+    try dumpTableOfContents(writer, indent_step, doc.toc);
     try dumpBlockListField(writer, indent_step, "contents", doc.contents);
     try dumpOptionalStringListField(writer, indent_step, "ids", doc.content_ids);
     // TODO: Dump ID map
@@ -442,8 +482,10 @@ test "render escapes string values" {
         .arena = std.heap.ArenaAllocator.init(std.testing.allocator),
         .version = .{ .major = 1, .minor = 2 },
         .contents = &.{},
-        .ids = &.{},
-        .lang = null,
+        .content_ids = &.{},
+        .id_map = .{},
+        .toc = undefined,
+        .lang = .inherit,
         .title = title,
         .author = null,
         .date = null,
@@ -452,6 +494,13 @@ test "render escapes string values" {
     defer doc.deinit();
 
     const arena_alloc = doc.arena.allocator();
+    doc.contents = try arena_alloc.alloc(hdoc.Block, 0);
+    doc.content_ids = try arena_alloc.alloc(?hdoc.Reference, 0);
+    doc.toc = .{
+        .level = .h1,
+        .headings = try arena_alloc.alloc(usize, 0),
+        .children = try arena_alloc.alloc(hdoc.Document.TableOfContents, 0),
+    };
 
     const spans = try arena_alloc.alloc(hdoc.Span, 1);
     spans[0] = .{
@@ -463,7 +512,7 @@ test "render escapes string values" {
     blocks[0] = .{
         .heading = .{
             .level = .h1,
-            .lang = null,
+            .lang = .inherit,
             .content = spans,
         },
     };
@@ -471,7 +520,19 @@ test "render escapes string values" {
 
     const ids = try arena_alloc.alloc(?hdoc.Reference, 1);
     ids[0] = id_value;
-    doc.ids = ids;
+    doc.content_ids = ids;
+
+    const headings = try arena_alloc.alloc(usize, 1);
+    headings[0] = 0;
+
+    const children = try arena_alloc.alloc(hdoc.Document.TableOfContents, 1);
+    children[0] = .{ .level = .h2, .headings = &.{}, .children = &.{} };
+
+    doc.toc = .{
+        .level = .h1,
+        .headings = headings,
+        .children = children,
+    };
 
     var buffer = Writer.Allocating.init(std.testing.allocator);
     defer buffer.deinit();

--- a/src/testsuite.zig
+++ b/src/testsuite.zig
@@ -357,6 +357,50 @@ test "parser handles unknown node types" {
     }
 }
 
+test "table of contents inserts automatic headings when skipping levels" {
+    const source =
+        \\hdoc(version="2.0");
+        \\h3{Third}
+        \\h2{Second}
+        \\h1{First}
+    ;
+
+    var diagnostics: hdoc.Diagnostics = .init(std.testing.allocator);
+    defer diagnostics.deinit();
+
+    var doc = try hdoc.parse(std.testing.allocator, source, &diagnostics);
+    defer doc.deinit();
+
+    try std.testing.expectEqual(@as(usize, 3), diagnostics.items.items.len);
+    try std.testing.expect(diagnosticCodesEqual(diagnostics.items.items[0].code, .missing_document_language));
+    try std.testing.expect(diagnosticCodesEqual(diagnostics.items.items[1].code, .{ .automatic_heading_insertion = .{ .level = .h1 } }));
+    try std.testing.expect(diagnosticCodesEqual(diagnostics.items.items[2].code, .{ .automatic_heading_insertion = .{ .level = .h2 } }));
+
+    const toc = doc.toc;
+    try std.testing.expectEqual(hdoc.Block.HeadingLevel.h1, toc.level);
+    try std.testing.expectEqualSlices(usize, &.{ 0, 2 }, toc.headings);
+    try std.testing.expectEqual(@as(usize, 2), toc.children.len);
+
+    const auto_h1 = toc.children[0];
+    try std.testing.expectEqual(hdoc.Block.HeadingLevel.h2, auto_h1.level);
+    try std.testing.expectEqualSlices(usize, &.{ 0, 1 }, auto_h1.headings);
+    try std.testing.expectEqual(@as(usize, 2), auto_h1.children.len);
+
+    const auto_h2 = auto_h1.children[0];
+    try std.testing.expectEqual(hdoc.Block.HeadingLevel.h3, auto_h2.level);
+    try std.testing.expectEqualSlices(usize, &.{0}, auto_h2.headings);
+
+    const h2_child = auto_h1.children[1];
+    try std.testing.expectEqual(hdoc.Block.HeadingLevel.h3, h2_child.level);
+    try std.testing.expectEqual(@as(usize, 0), h2_child.headings.len);
+    try std.testing.expectEqual(@as(usize, 0), h2_child.children.len);
+
+    const trailing_h1_child = toc.children[1];
+    try std.testing.expectEqual(hdoc.Block.HeadingLevel.h2, trailing_h1_child.level);
+    try std.testing.expectEqual(@as(usize, 0), trailing_h1_child.headings.len);
+    try std.testing.expectEqual(@as(usize, 0), trailing_h1_child.children.len);
+}
+
 fn diagnosticCodesEqual(lhs: hdoc.Diagnostic.Code, rhs: hdoc.Diagnostic.Code) bool {
     if (std.meta.activeTag(lhs) != std.meta.activeTag(rhs))
         return false;


### PR DESCRIPTION
## Summary
- build a document-level table of contents tree from parsed headings
- insert automatic toc entries when heading levels are skipped and emit warnings
- expose the toc in dump output and add coverage for hierarchical gap handling

## Testing
- zig build
- zig build test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954522275c48322a5a389aaea78a12c)