### PR TITLE
Implement HTML5 renderer

### DIFF
--- a/src/render/html5.zig
+++ b/src/render/html5.zig
@@ -5,32 +5,511 @@ const std = @import("std");
 const hdoc = @import("../hyperdoc.zig");
 
 const Writer = std.Io.Writer;
+const RenderError = Writer.Error || error{NoSpaceLeft};
 const indent_step: usize = 2;
 
-// TODO: Implementation hints:
-// - Use writeStartTag, writeEndTag to construct the document
-// - Use and expand writeEscapedHtml to suite the needs of HyperDoc.
-// - Implement a custom formatter for string attribute values so they have proper escaping applied.
-// - Use semantic HTML. Never use `div` or `span`. If necessary, ask back when you encounter the need for a "custom tag".
-// - For the different paragraph types, use a class="hdoc-${kind}", so for example class="hdoc-warning" to distinguish the special paragraphs from regular <p> ones.
-// - The TOC element must be unrolled manually and should auto-link to the h1,h2,h3 elements.
+pub fn render(doc: hdoc.Document, writer: *Writer) RenderError!void {
+    var ctx: RenderContext = .{ .doc = &doc, .writer = writer };
 
-/// This function emits the body-only part of a HyperDoc document as
-/// valid HTML5.
-pub fn render(doc: hdoc.Document, writer: *Writer) Writer.Error!void {
-    _ = doc;
-
-    // TODO: Implement this proper
-
-    try writeStartTag(writer, "p", .regular, .{
-        .style = "font-weight: bold",
-    });
-    try writeEscapedHtml(writer, "Hello, World!");
-    try writeEndTag(writer, "p");
-    try writer.writeAll("\n");
+    for (doc.contents, 0..) |block, index| {
+        try ctx.renderBlock(block, index, 0);
+    }
 }
 
-fn writeEscapedHtml(writer: *Writer, text: []const u8) !void {
+const RenderContext = struct {
+    doc: *const hdoc.Document,
+    writer: *Writer,
+
+    fn renderBlock(ctx: *RenderContext, block: hdoc.Block, block_index: ?usize, indent: usize) RenderError!void {
+        switch (block) {
+            .heading => |heading| try ctx.renderHeading(heading, block_index, indent),
+            .paragraph => |paragraph| try ctx.renderParagraph(paragraph, block_index, indent),
+            .list => |list| try ctx.renderList(list, block_index, indent),
+            .image => |image| try ctx.renderImage(image, block_index, indent),
+            .preformatted => |preformatted| try ctx.renderPreformatted(preformatted, block_index, indent),
+            .toc => |toc| try ctx.renderTableOfContents(toc, block_index, indent),
+            .table => |table| try ctx.renderTable(table, block_index, indent),
+        }
+    }
+
+    fn renderBlocks(ctx: *RenderContext, blocks: []const hdoc.Block, indent: usize) RenderError!void {
+        for (blocks) |block| {
+            try ctx.renderBlock(block, null, indent);
+        }
+    }
+
+    fn renderHeading(ctx: *RenderContext, heading: hdoc.Block.Heading, block_index: ?usize, indent: usize) RenderError!void {
+        const lang_attr = langAttribute(heading.lang);
+
+        var id_buffer: [32]u8 = undefined;
+        const id_attr = if (block_index) |idx|
+            ctx.resolveHeadingId(idx, &id_buffer)
+        else
+            null;
+
+        try writeIndent(ctx.writer, indent);
+        try writeStartTag(ctx.writer, headingTag(heading.level), .regular, .{
+            .id = id_attr,
+            .lang = lang_attr,
+        });
+        try ctx.renderSpans(heading.content);
+        try writeEndTag(ctx.writer, headingTag(heading.level));
+        try ctx.writer.writeByte('\n');
+    }
+
+    fn renderParagraph(ctx: *RenderContext, paragraph: hdoc.Block.Paragraph, block_index: ?usize, indent: usize) RenderError!void {
+        const lang_attr = langAttribute(paragraph.lang);
+        const id_attr = ctx.resolveBlockId(block_index);
+
+        var class_buffer: [32]u8 = undefined;
+        const class_attr: ?[]const u8 = switch (paragraph.kind) {
+            .p => null,
+            else => std.fmt.bufPrint(&class_buffer, "hdoc-{s}", .{@tagName(paragraph.kind)}) catch unreachable,
+        };
+
+        try writeIndent(ctx.writer, indent);
+        try writeStartTag(ctx.writer, "p", .regular, .{
+            .id = id_attr,
+            .lang = lang_attr,
+            .class = class_attr,
+        });
+        try ctx.renderSpans(paragraph.content);
+        try writeEndTag(ctx.writer, "p");
+        try ctx.writer.writeByte('\n');
+    }
+
+    fn renderList(ctx: *RenderContext, list: hdoc.Block.List, block_index: ?usize, indent: usize) RenderError!void {
+        const lang_attr = langAttribute(list.lang);
+        const id_attr = ctx.resolveBlockId(block_index);
+
+        const tag = if (list.first != null)
+            "ol"
+        else
+            "ul";
+
+        try writeIndent(ctx.writer, indent);
+        if (std.mem.eql(u8, tag, "ol")) {
+            try writeStartTag(ctx.writer, tag, .regular, .{
+                .id = id_attr,
+                .lang = lang_attr,
+                .start = list.first,
+            });
+        } else {
+            try writeStartTag(ctx.writer, tag, .regular, .{
+                .id = id_attr,
+                .lang = lang_attr,
+            });
+        }
+        try ctx.writer.writeByte('\n');
+
+        for (list.items) |item| {
+            try writeIndent(ctx.writer, indent + indent_step);
+            try writeStartTag(ctx.writer, "li", .regular, .{ .lang = langAttribute(item.lang) });
+            if (item.content.len > 0) {
+                try ctx.writer.writeByte('\n');
+                try ctx.renderBlocks(item.content, indent + 2 * indent_step);
+                try writeIndent(ctx.writer, indent + indent_step);
+            }
+            try writeEndTag(ctx.writer, "li");
+            try ctx.writer.writeByte('\n');
+        }
+
+        try writeIndent(ctx.writer, indent);
+        try writeEndTag(ctx.writer, tag);
+        try ctx.writer.writeByte('\n');
+    }
+
+    fn renderImage(ctx: *RenderContext, image: hdoc.Block.Image, block_index: ?usize, indent: usize) RenderError!void {
+        const lang_attr = langAttribute(image.lang);
+        const id_attr = ctx.resolveBlockId(block_index);
+
+        try writeIndent(ctx.writer, indent);
+        try writeStartTag(ctx.writer, "figure", .regular, .{ .id = id_attr, .lang = lang_attr });
+        try ctx.writer.writeByte('\n');
+
+        try writeIndent(ctx.writer, indent + indent_step);
+        try writeStartTag(ctx.writer, "img", .auto_close, .{
+            .src = image.path,
+            .alt = image.alt,
+        });
+        try ctx.writer.writeByte('\n');
+
+        if (image.content.len > 0) {
+            try writeIndent(ctx.writer, indent + indent_step);
+            try writeStartTag(ctx.writer, "figcaption", .regular, .{});
+            try ctx.renderSpans(image.content);
+            try writeEndTag(ctx.writer, "figcaption");
+            try ctx.writer.writeByte('\n');
+        }
+
+        try writeIndent(ctx.writer, indent);
+        try writeEndTag(ctx.writer, "figure");
+        try ctx.writer.writeByte('\n');
+    }
+
+    fn renderPreformatted(ctx: *RenderContext, preformatted: hdoc.Block.Preformatted, block_index: ?usize, indent: usize) RenderError!void {
+        const lang_attr = langAttribute(preformatted.lang);
+        const id_attr = ctx.resolveBlockId(block_index);
+
+        try writeIndent(ctx.writer, indent);
+        try writeStartTag(ctx.writer, "pre", .regular, .{ .id = id_attr, .lang = lang_attr });
+        const class_attr = "hdoc-code";
+        if (preformatted.syntax) |syntax| {
+            try writeStartTag(ctx.writer, "code", .regular, .{ .class = class_attr, .data_syntax = syntax });
+        } else {
+            try writeStartTag(ctx.writer, "code", .regular, .{ .class = class_attr });
+        }
+        try ctx.renderSpans(preformatted.content);
+        try writeEndTag(ctx.writer, "code");
+        try writeEndTag(ctx.writer, "pre");
+        try ctx.writer.writeByte('\n');
+    }
+
+    fn renderTableOfContents(ctx: *RenderContext, toc_block: hdoc.Block.TableOfContents, block_index: ?usize, indent: usize) RenderError!void {
+        const depth = toc_block.depth orelse 3;
+        const lang_attr = langAttribute(toc_block.lang);
+        const id_attr = ctx.resolveBlockId(block_index);
+
+        if (!tocHasEntries(ctx.doc.toc)) {
+            return;
+        }
+
+        try writeIndent(ctx.writer, indent);
+        try writeStartTag(ctx.writer, "nav", .regular, .{
+            .id = id_attr,
+            .lang = lang_attr,
+            .aria_label = "Table of contents",
+        });
+        try ctx.writer.writeByte('\n');
+
+        try ctx.renderTocList(ctx.doc.toc, indent + indent_step, depth, 1);
+
+        try writeIndent(ctx.writer, indent);
+        try writeEndTag(ctx.writer, "nav");
+        try ctx.writer.writeByte('\n');
+    }
+
+    fn renderTocList(ctx: *RenderContext, node: hdoc.Document.TableOfContents, indent: usize, max_depth: u8, current_depth: u8) RenderError!void {
+        if (node.headings.len == 0) {
+            return;
+        }
+
+        try writeIndent(ctx.writer, indent);
+        try writeStartTag(ctx.writer, "ol", .regular, .{});
+        try ctx.writer.writeByte('\n');
+
+        for (node.headings, 0..) |heading_index, child_index| {
+            try writeIndent(ctx.writer, indent + indent_step);
+            try writeStartTag(ctx.writer, "li", .regular, .{});
+
+            const heading_block = ctx.doc.contents[heading_index].heading;
+            var id_buffer: [32]u8 = undefined;
+            const target_id = ctx.resolveHeadingId(heading_index, &id_buffer);
+
+            var href_buffer: [64]u8 = undefined;
+            const href = std.fmt.bufPrint(&href_buffer, "#{s}", .{target_id}) catch unreachable;
+
+            try writeStartTag(ctx.writer, "a", .regular, .{ .href = href });
+            try ctx.renderSpans(heading_block.content);
+            try writeEndTag(ctx.writer, "a");
+
+            const child_allowed = current_depth < max_depth and
+                child_index < node.children.len and
+                tocHasEntries(node.children[child_index]);
+            if (child_allowed) {
+                try ctx.writer.writeByte('\n');
+                try ctx.renderTocList(node.children[child_index], indent + 2 * indent_step, max_depth, current_depth + 1);
+                try writeIndent(ctx.writer, indent + indent_step);
+            }
+
+            try writeEndTag(ctx.writer, "li");
+            try ctx.writer.writeByte('\n');
+        }
+
+        try writeIndent(ctx.writer, indent);
+        try writeEndTag(ctx.writer, "ol");
+        try ctx.writer.writeByte('\n');
+    }
+
+    fn renderTable(ctx: *RenderContext, table: hdoc.Block.Table, block_index: ?usize, indent: usize) RenderError!void {
+        const lang_attr = langAttribute(table.lang);
+        const id_attr = ctx.resolveBlockId(block_index);
+
+        const column_count = inferColumnCount(table.rows) orelse 0;
+        const has_title_column = tableHasTitleColumn(table.rows);
+
+        try writeIndent(ctx.writer, indent);
+        try writeStartTag(ctx.writer, "table", .regular, .{ .id = id_attr, .lang = lang_attr });
+        try ctx.writer.writeByte('\n');
+
+        const header_index = findHeaderIndex(table.rows);
+        if (header_index) |index| {
+            try writeIndent(ctx.writer, indent + indent_step);
+            try writeStartTag(ctx.writer, "thead", .regular, .{});
+            try ctx.writer.writeByte('\n');
+            try ctx.renderHeaderRow(table.rows[index].columns, indent + 2 * indent_step, has_title_column);
+            try writeIndent(ctx.writer, indent + indent_step);
+            try writeEndTag(ctx.writer, "thead");
+            try ctx.writer.writeByte('\n');
+        }
+
+        try writeIndent(ctx.writer, indent + indent_step);
+        try writeStartTag(ctx.writer, "tbody", .regular, .{});
+        try ctx.writer.writeByte('\n');
+
+        for (table.rows, 0..) |row, index| {
+            if (header_index) |head_idx| {
+                if (index == head_idx) continue;
+            }
+            switch (row) {
+                .columns => |columns| try ctx.renderHeaderRow(columns, indent + 2 * indent_step, has_title_column),
+                .row => |data_row| try ctx.renderDataRow(data_row, indent + 2 * indent_step, has_title_column),
+                .group => |group| try ctx.renderGroupRow(group, indent + 2 * indent_step, column_count, has_title_column),
+            }
+        }
+
+        try writeIndent(ctx.writer, indent + indent_step);
+        try writeEndTag(ctx.writer, "tbody");
+        try ctx.writer.writeByte('\n');
+
+        try writeIndent(ctx.writer, indent);
+        try writeEndTag(ctx.writer, "table");
+        try ctx.writer.writeByte('\n');
+    }
+
+    fn renderHeaderRow(ctx: *RenderContext, columns: hdoc.Block.TableColumns, indent: usize, has_title_column: bool) RenderError!void {
+        try writeIndent(ctx.writer, indent);
+        try writeStartTag(ctx.writer, "tr", .regular, .{ .lang = langAttribute(columns.lang) });
+        try ctx.writer.writeByte('\n');
+
+        if (has_title_column) {
+            try writeIndent(ctx.writer, indent + indent_step);
+            try writeStartTag(ctx.writer, "th", .regular, .{ .scope = "col" });
+            try writeEndTag(ctx.writer, "th");
+            try ctx.writer.writeByte('\n');
+        }
+
+        for (columns.cells) |cell| {
+            try ctx.renderTableCellWithScope(cell, indent + indent_step, true, "col");
+        }
+
+        try writeIndent(ctx.writer, indent);
+        try writeEndTag(ctx.writer, "tr");
+        try ctx.writer.writeByte('\n');
+    }
+
+    fn renderDataRow(ctx: *RenderContext, row: hdoc.Block.TableDataRow, indent: usize, has_title_column: bool) RenderError!void {
+        try writeIndent(ctx.writer, indent);
+        try writeStartTag(ctx.writer, "tr", .regular, .{ .lang = langAttribute(row.lang) });
+        try ctx.writer.writeByte('\n');
+
+        if (has_title_column) {
+            try writeIndent(ctx.writer, indent + indent_step);
+            try writeStartTag(ctx.writer, "th", .regular, .{ .scope = "row" });
+            if (row.title) |title| {
+                try writeEscapedHtml(ctx.writer, title);
+            }
+            try writeEndTag(ctx.writer, "th");
+            try ctx.writer.writeByte('\n');
+        }
+
+        for (row.cells) |cell| {
+            try ctx.renderTableCell(cell, indent + indent_step, false);
+        }
+
+        try writeIndent(ctx.writer, indent);
+        try writeEndTag(ctx.writer, "tr");
+        try ctx.writer.writeByte('\n');
+    }
+
+    fn renderGroupRow(ctx: *RenderContext, group: hdoc.Block.TableGroup, indent: usize, column_count: usize, has_title_column: bool) RenderError!void {
+        try writeIndent(ctx.writer, indent);
+        try writeStartTag(ctx.writer, "tr", .regular, .{ .lang = langAttribute(group.lang) });
+        try ctx.writer.writeByte('\n');
+
+        if (has_title_column) {
+            try writeIndent(ctx.writer, indent + indent_step);
+            try writeStartTag(ctx.writer, "td", .regular, .{});
+            try writeEndTag(ctx.writer, "td");
+            try ctx.writer.writeByte('\n');
+        }
+
+        try writeIndent(ctx.writer, indent + indent_step);
+        try writeStartTag(ctx.writer, "th", .regular, .{
+            .scope = "colgroup",
+            .colspan = @as(u32, @intCast(@max(@as(usize, 1), column_count))),
+        });
+        try ctx.renderSpans(group.content);
+        try writeEndTag(ctx.writer, "th");
+        try ctx.writer.writeByte('\n');
+
+        try writeIndent(ctx.writer, indent);
+        try writeEndTag(ctx.writer, "tr");
+        try ctx.writer.writeByte('\n');
+    }
+
+    fn renderTableCell(ctx: *RenderContext, cell: hdoc.Block.TableCell, indent: usize, is_header: bool) RenderError!void {
+        try ctx.renderTableCellWithScope(cell, indent, is_header, null);
+    }
+
+    fn renderTableCellWithScope(ctx: *RenderContext, cell: hdoc.Block.TableCell, indent: usize, is_header: bool, scope: ?[]const u8) RenderError!void {
+        const tag = if (is_header) "th" else "td";
+        const lang_attr = langAttribute(cell.lang);
+        const colspan_attr: ?u32 = if (cell.colspan > 1) cell.colspan else null;
+
+        try writeIndent(ctx.writer, indent);
+        try writeStartTag(ctx.writer, tag, .regular, .{ .lang = lang_attr, .colspan = colspan_attr, .scope = scope });
+        if (cell.content.len > 0) {
+            try ctx.writer.writeByte('\n');
+            try ctx.renderBlocks(cell.content, indent + indent_step);
+            try writeIndent(ctx.writer, indent);
+        }
+        try writeEndTag(ctx.writer, tag);
+        try ctx.writer.writeByte('\n');
+    }
+
+    fn resolveHeadingId(ctx: *RenderContext, index: usize, buffer: *[32]u8) []const u8 {
+        if (index < ctx.doc.content_ids.len) {
+            if (ctx.doc.content_ids[index]) |value| {
+                return value.text;
+            }
+        }
+
+        return std.fmt.bufPrint(buffer, "hdoc-auto-{d}", .{index}) catch unreachable;
+    }
+
+    fn resolveBlockId(ctx: *RenderContext, block_index: ?usize) ?[]const u8 {
+        if (block_index) |idx| {
+            if (idx < ctx.doc.content_ids.len) {
+                if (ctx.doc.content_ids[idx]) |value| {
+                    return value.text;
+                }
+            }
+        }
+        return null;
+    }
+
+    fn renderSpans(ctx: *RenderContext, spans: []const hdoc.Span) RenderError!void {
+        for (spans) |span| {
+            try ctx.renderSpan(span);
+        }
+    }
+
+    fn renderSpan(ctx: *RenderContext, span: hdoc.Span) RenderError!void {
+        var pending_lang = langAttribute(span.attribs.lang);
+
+        var opened: [6][]const u8 = undefined;
+        var opened_len: usize = 0;
+
+        const link_tag = span.attribs.link != .none;
+        if (link_tag) {
+            const href_value = switch (span.attribs.link) {
+                .none => unreachable,
+                .ref => |reference| blk: {
+                    var href_buffer: [128]u8 = undefined;
+                    break :blk std.fmt.bufPrint(&href_buffer, "#{s}", .{reference.text}) catch unreachable;
+                },
+                .uri => |uri| uri.text,
+            };
+
+            try writeStartTag(ctx.writer, "a", .regular, .{ .href = href_value, .lang = takeLang(&pending_lang) });
+            opened[opened_len] = "a";
+            opened_len += 1;
+        }
+
+        switch (span.attribs.position) {
+            .baseline => {},
+            .subscript => {
+                try writeStartTag(ctx.writer, "sub", .regular, .{ .lang = takeLang(&pending_lang) });
+                opened[opened_len] = "sub";
+                opened_len += 1;
+            },
+            .superscript => {
+                try writeStartTag(ctx.writer, "sup", .regular, .{ .lang = takeLang(&pending_lang) });
+                opened[opened_len] = "sup";
+                opened_len += 1;
+            },
+        }
+
+        if (span.attribs.strike) {
+            try writeStartTag(ctx.writer, "s", .regular, .{ .lang = takeLang(&pending_lang) });
+            opened[opened_len] = "s";
+            opened_len += 1;
+        }
+
+        if (span.attribs.em) {
+            try writeStartTag(ctx.writer, "em", .regular, .{ .lang = takeLang(&pending_lang) });
+            opened[opened_len] = "em";
+            opened_len += 1;
+        }
+
+        if (span.attribs.mono) {
+            const syntax_attr = if (span.attribs.syntax.len > 0) span.attribs.syntax else null;
+            try writeStartTag(ctx.writer, "code", .regular, .{ .lang = takeLang(&pending_lang), .class = "hdoc-code", .data_syntax = syntax_attr });
+            opened[opened_len] = "code";
+            opened_len += 1;
+        }
+
+        const content_lang = takeLang(&pending_lang);
+        switch (span.content) {
+            .text => |text| {
+                if (content_lang) |lang| {
+                    try writeStartTag(ctx.writer, "bdi", .regular, .{ .lang = lang });
+                    try writeEscapedHtml(ctx.writer, text);
+                    try writeEndTag(ctx.writer, "bdi");
+                } else {
+                    try writeEscapedHtml(ctx.writer, text);
+                }
+            },
+            .date => |date| try ctx.renderDateTimeValue(.date, date, content_lang),
+            .time => |time| try ctx.renderDateTimeValue(.time, time, content_lang),
+            .datetime => |datetime| try ctx.renderDateTimeValue(.datetime, datetime, content_lang),
+        }
+
+        while (opened_len > 0) {
+            opened_len -= 1;
+            try writeEndTag(ctx.writer, opened[opened_len]);
+        }
+    }
+
+    fn renderDateTimeValue(ctx: *RenderContext, comptime kind: enum { date, time, datetime }, value: anytype, lang_attr: ?[]const u8) RenderError!void {
+        var datetime_buffer: [128]u8 = undefined;
+        const datetime_value = switch (kind) {
+            .date => try formatIsoDate(value.value, &datetime_buffer),
+            .time => try formatIsoTime(value.value, &datetime_buffer),
+            .datetime => try formatIsoDateTime(value.value, &datetime_buffer),
+        };
+
+        var display_buffer: [128]u8 = undefined;
+        const display_text = switch (kind) {
+            .date => try formatDateValue(value, &display_buffer),
+            .time => try formatTimeValue(value, &display_buffer),
+            .datetime => try formatDateTimeValue(value, &display_buffer),
+        };
+
+        try writeStartTag(ctx.writer, "time", .regular, .{ .datetime = datetime_value, .lang = lang_attr });
+        try ctx.writer.writeAll(display_text);
+        try writeEndTag(ctx.writer, "time");
+    }
+};
+
+fn writeIndent(writer: *Writer, indent: usize) RenderError!void {
+    var i: usize = 0;
+    while (i < indent) : (i += 1) {
+        try writer.writeByte(' ');
+    }
+}
+
+fn writeAttributeName(writer: *Writer, name: []const u8) RenderError!void {
+    for (name) |char| {
+        if (char == '_')
+            try writer.writeByte('-')
+        else
+            try writer.writeByte(char);
+    }
+}
+
+fn writeEscapedHtml(writer: *Writer, text: []const u8) RenderError!void {
     var view = std.unicode.Utf8View.init(text) catch @panic("invalid utf-8 passed");
     var iter = view.iterator();
     while (iter.nextCodepointSlice()) |slice| {
@@ -44,58 +523,276 @@ fn writeEscapedHtml(writer: *Writer, text: []const u8) !void {
 
             0xA0 => try writer.writeAll("&nbsp;"),
 
-            // TODO: Fill out other required codes.
-
             else => try writer.writeAll(slice),
         }
     }
 }
 
-fn writeStartTag(writer: *Writer, tag: []const u8, style: enum { regular, auto_close }, attribs: anytype) !void {
+fn writeStartTag(writer: *Writer, tag: []const u8, style: enum { regular, auto_close }, attribs: anytype) RenderError!void {
     try writer.print("<{s}", .{tag});
 
     const Attribs = @TypeOf(attribs);
     inline for (@typeInfo(Attribs).@"struct".fields) |fld| {
         const value = @field(attribs, fld.name);
-
-        if (fld.type == bool) {
-            if (value) {
-                try writer.print(" {s}", .{fld.name});
-            }
-        } else {
-            try writer.print(" {s}=", .{fld.name});
-
-            switch (@typeInfo(fld.type)) {
-                .int, .comptime_int => try writer.print("\"{}\"", .{value}),
-                .float, .comptime_float => try writer.print("\"{d}\"", .{value}),
-
-                .pointer => |info| if (info.size == .one) {
-                    const child = @typeInfo(info.child);
-
-                    if (child != .array)
-                        @compileError("unsupported pointer type " ++ @typeName(fld.type));
-                    if (child.array.child != u8)
-                        @compileError("unsupported pointer type " ++ @typeName(fld.type));
-
-                    try writer.print("\"{s}\"", .{value}); // TODO: Implement proper HTML escaping!
-                },
-
-                else => switch (fld.type) {
-                    bool => unreachable,
-
-                    []u8, []const u8 => try writer.print("\"{s}\"", .{value}), // TODO: Implement proper HTML escaping!
-
-                    else => @compileError("unsupported tag type " ++ @typeName(fld.type) ++ ", implement support above."),
-                },
-            }
-        }
+        try writeAttribute(writer, fld.name, value);
     }
+
     switch (style) {
         .auto_close => try writer.writeAll("/>"),
         .regular => try writer.writeAll(">"),
     }
 }
 
-fn writeEndTag(writer: *Writer, tag: []const u8) !void {
+fn writeAttribute(writer: *Writer, name: []const u8, value: anytype) RenderError!void {
+    const T = @TypeOf(value);
+    switch (@typeInfo(T)) {
+        .bool => {
+            if (value) {
+                try writer.writeByte(' ');
+                try writeAttributeName(writer, name);
+            }
+        },
+        .optional => {
+            if (value) |inner| {
+                try writeAttribute(writer, name, inner);
+            }
+        },
+        .int, .comptime_int => try writeNumericAttribute(writer, name, value),
+        .float, .comptime_float => try writeFloatAttribute(writer, name, value),
+        .@"enum" => try writeStringAttribute(writer, name, @tagName(value)),
+        .pointer => |info| switch (info.size) {
+            .slice => {
+                if (info.child != u8) @compileError("unsupported pointer type " ++ @typeName(T));
+                try writeStringAttribute(writer, name, value);
+            },
+            .one => {
+                const child = @typeInfo(info.child);
+                if (child != .array) @compileError("unsupported pointer type " ++ @typeName(T));
+                if (child.array.child != u8) @compileError("unsupported pointer type " ++ @typeName(T));
+                const slice: []const u8 = value[0..child.array.len];
+                try writeStringAttribute(writer, name, slice);
+            },
+            else => @compileError("unsupported pointer type " ++ @typeName(T)),
+        },
+        .array => |info| {
+            if (info.child != u8) @compileError("unsupported array type " ++ @typeName(T));
+            const slice: []const u8 = value[0..];
+            try writeStringAttribute(writer, name, slice);
+        },
+        else => switch (T) {
+            []u8, []const u8 => try writeStringAttribute(writer, name, value),
+            else => @compileError("unsupported tag type " ++ @typeName(T) ++ ", implement support above."),
+        },
+    }
+}
+
+fn writeStringAttribute(writer: *Writer, name: []const u8, value: []const u8) RenderError!void {
+    try writer.writeByte(' ');
+    try writeAttributeName(writer, name);
+    try writer.writeByte('=');
+    try writer.writeByte('"');
+    try writeEscapedHtml(writer, value);
+    try writer.writeByte('"');
+}
+
+fn writeNumericAttribute(writer: *Writer, name: []const u8, value: anytype) RenderError!void {
+    try writer.writeByte(' ');
+    try writeAttributeName(writer, name);
+    try writer.print("=\"{}\"", .{value});
+}
+
+fn writeFloatAttribute(writer: *Writer, name: []const u8, value: anytype) RenderError!void {
+    try writer.writeByte(' ');
+    try writeAttributeName(writer, name);
+    try writer.print("=\"{d}\"", .{value});
+}
+
+fn writeEndTag(writer: *Writer, tag: []const u8) RenderError!void {
     try writer.print("</{s}>", .{tag});
+}
+
+fn langAttribute(lang: hdoc.LanguageTag) ?[]const u8 {
+    if (lang.text.len == 0)
+        return null;
+    return lang.text;
+}
+
+fn takeLang(lang: *?[]const u8) ?[]const u8 {
+    if (lang.*) |value| {
+        lang.* = null;
+        return value;
+    }
+    return null;
+}
+
+fn headingTag(level: hdoc.Block.HeadingLevel) []const u8 {
+    return switch (level) {
+        .h1 => "h1",
+        .h2 => "h2",
+        .h3 => "h3",
+    };
+}
+
+fn tocHasEntries(node: hdoc.Document.TableOfContents) bool {
+    if (node.headings.len > 0) return true;
+    for (node.children) |child| {
+        if (tocHasEntries(child)) return true;
+    }
+    return false;
+}
+
+fn inferColumnCount(rows: []const hdoc.Block.TableRow) ?usize {
+    for (rows) |row| {
+        switch (row) {
+            .columns => |columns| {
+                var width: usize = 0;
+                for (columns.cells) |cell| {
+                    width += cell.colspan;
+                }
+                return width;
+            },
+            .row => |data_row| {
+                var width: usize = 0;
+                for (data_row.cells) |cell| {
+                    width += cell.colspan;
+                }
+                return width;
+            },
+            .group => {},
+        }
+    }
+    return null;
+}
+
+fn tableHasTitleColumn(rows: []const hdoc.Block.TableRow) bool {
+    for (rows) |row| {
+        switch (row) {
+            .row => |data_row| if (data_row.title != null) return true,
+            .group => return true,
+            .columns => {},
+        }
+    }
+    return false;
+}
+
+fn findHeaderIndex(rows: []const hdoc.Block.TableRow) ?usize {
+    for (rows, 0..) |row, index| {
+        if (row == .columns) return index;
+    }
+    return null;
+}
+
+fn formatIsoDate(value: hdoc.Date, buffer: []u8) RenderError![]const u8 {
+    return std.fmt.bufPrint(buffer, "{d:0>4}-{d:0>2}-{d:0>2}", .{ value.year, value.month, value.day }) catch unreachable;
+}
+
+fn writeTimeZone(writer: anytype, timezone: hdoc.TimeZoneOffset) RenderError!void {
+    const minutes = @intFromEnum(timezone);
+    if (minutes == 0) {
+        try writer.writeByte('Z');
+        return;
+    }
+
+    const sign: u8 = if (minutes < 0) '-' else '+';
+    const abs_minutes: u32 = @intCast(@abs(minutes));
+    const hour: u32 = abs_minutes / 60;
+    const minute: u32 = abs_minutes % 60;
+
+    try writer.print("{c}{d:0>2}:{d:0>2}", .{ sign, hour, minute });
+}
+
+fn formatIsoTime(value: hdoc.Time, buffer: []u8) RenderError![]const u8 {
+    var stream = std.io.fixedBufferStream(buffer);
+    const writer = stream.writer();
+
+    try writer.print("{d:0>2}:{d:0>2}:{d:0>2}", .{ value.hour, value.minute, value.second });
+    if (value.microsecond > 0) {
+        try writer.print(".{d:0>6}", .{value.microsecond});
+    }
+    try writeTimeZone(writer, value.timezone);
+
+    return stream.getWritten();
+}
+
+fn formatIsoDateTime(value: hdoc.DateTime, buffer: []u8) RenderError![]const u8 {
+    var date_buffer: [32]u8 = undefined;
+    var time_buffer: [64]u8 = undefined;
+
+    const date_text = try formatIsoDate(value.date, &date_buffer);
+    const time_text = try formatIsoTime(value.time, &time_buffer);
+
+    return std.fmt.bufPrint(buffer, "{s}T{s}", .{ date_text, time_text }) catch unreachable;
+}
+
+fn formatDateValue(value: hdoc.FormattedDateTime(hdoc.Date), buffer: []u8) RenderError![]const u8 {
+    return switch (value.format) {
+        .year => std.fmt.bufPrint(buffer, "{d}", .{value.value.year}) catch unreachable,
+        .month => std.fmt.bufPrint(buffer, "{d:0>4}-{d:0>2}", .{ value.value.year, value.value.month }) catch unreachable,
+        .day => std.fmt.bufPrint(buffer, "{d:0>2}", .{value.value.day}) catch unreachable,
+        .weekday => std.fmt.bufPrint(buffer, "{s}", .{weekdayName(value.value)}) catch unreachable,
+        .short, .long, .relative, .iso => formatIsoDate(value.value, buffer),
+    };
+}
+
+fn formatTimeValue(value: hdoc.FormattedDateTime(hdoc.Time), buffer: []u8) RenderError![]const u8 {
+    var stream = std.io.fixedBufferStream(buffer);
+    const writer = stream.writer();
+
+    switch (value.format) {
+        .short, .rough => try writer.print("{d:0>2}:{d:0>2}", .{ value.value.hour, value.value.minute }),
+        .long, .relative => {
+            try writer.print("{d:0>2}:{d:0>2}:{d:0>2}", .{ value.value.hour, value.value.minute, value.value.second });
+            if (value.value.microsecond > 0) {
+                try writer.print(".{d:0>6}", .{value.value.microsecond});
+            }
+        },
+        .iso => try writer.writeAll(try formatIsoTime(value.value, buffer)),
+    }
+
+    if (value.format != .iso) {
+        try writer.writeByte(' ');
+        try writeTimeZone(writer, value.value.timezone);
+    }
+
+    return stream.getWritten();
+}
+
+fn formatDateTimeValue(value: hdoc.FormattedDateTime(hdoc.DateTime), buffer: []u8) RenderError![]const u8 {
+    var date_buffer: [32]u8 = undefined;
+    var time_buffer: [64]u8 = undefined;
+
+    const date_text = try formatIsoDate(value.value.date, &date_buffer);
+
+    return switch (value.format) {
+        .short => std.fmt.bufPrint(buffer, "{s} {s}", .{
+            date_text,
+            try formatTimeValue(.{ .format = .short, .value = value.value.time }, &time_buffer),
+        }) catch unreachable,
+        .long, .relative => std.fmt.bufPrint(buffer, "{s} {s}", .{
+            date_text,
+            try formatTimeValue(.{ .format = .long, .value = value.value.time }, &time_buffer),
+        }) catch unreachable,
+        .iso => formatIsoDateTime(value.value, buffer),
+    };
+}
+
+fn weekdayName(date: hdoc.Date) []const u8 {
+    const y = if (date.month < 3) date.year - 1 else date.year;
+    const m = if (date.month < 3) date.month + 12 else date.month;
+    const k: i32 = @mod(y, 100);
+    const j: i32 = @divTrunc(y, 100);
+
+    const day_component: i32 = @intCast(date.day);
+    const z: i32 = day_component + @divTrunc(13 * (m + 1), 5) + k + @divTrunc(k, 4) + @divTrunc(j, 4) + 5 * j;
+    const h: i32 = @mod(z, 7);
+    return switch (h) {
+        0 => "Saturday",
+        1 => "Sunday",
+        2 => "Monday",
+        3 => "Tuesday",
+        4 => "Wednesday",
+        5 => "Thursday",
+        6 => "Friday",
+        else => "",
+    };
 }

--- a/test/html5/AGENTS.md
+++ b/test/html5/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS
+
+These files are HTML5 renderer golden tests.
+
+- Each `.hdoc` example here is paired with a `.html` file rendered by `./zig-out/bin/hyperdoc`.
+- When changing the HTML5 renderer, update the corresponding `.html` outputs to match the new behavior.
+- Keep scenarios focused: each example should target specific constructs (paragraph styles, nesting, tables, media/toc, etc.).

--- a/test/html5/media_and_toc.hdoc
+++ b/test/html5/media_and_toc.hdoc
@@ -1,0 +1,21 @@
+hdoc(version="2.0", title="Media and TOC", lang="en", tz="+00:00");
+
+h1(id="intro") "Media and TOC"
+
+toc(depth="3");
+
+h2(id="code") "Preformatted"
+
+pre(syntax="python") { print("hello world") }
+
+h2(id="figure") "Figure"
+
+img(id="fig-code",path="./example.png",alt="Example figure") { Figure caption text. }
+
+h2(id="dates") "Dates and Times"
+
+p { Today is \date(fmt="iso"){2024-03-01}. }
+
+p { The meeting is at \time(fmt="long"){14:30:45+00:00}. }
+
+p { Release happens on \datetime(fmt="short"){2024-04-15T08:00:00+00:00}. }

--- a/test/html5/media_and_toc.html
+++ b/test/html5/media_and_toc.html
@@ -1,0 +1,23 @@
+<h1 id="intro">Media and TOC</h1>
+<nav aria-label="Table of contents">
+  <ol>
+    <li><a href="#intro">Media and TOC</a>
+      <ol>
+        <li><a href="#code">Preformatted</a></li>
+        <li><a href="#figure">Figure</a></li>
+        <li><a href="#dates">Dates and Times</a></li>
+      </ol>
+    </li>
+  </ol>
+</nav>
+<h2 id="code">Preformatted</h2>
+<pre><code class="hdoc-code" data-syntax="python"> print(&quot;hello world&quot;) </code></pre>
+<h2 id="figure">Figure</h2>
+<figure id="fig-code">
+  <img src="./example.png" alt="Example figure"/>
+  <figcaption>Figure caption text.</figcaption>
+</figure>
+<h2 id="dates">Dates and Times</h2>
+<p>Today is <time datetime="+2024-03-01">+2024-03-01</time>.</p>
+<p>The meeting is at <time datetime="14:30:45Z">14:30:45 Z</time>.</p>
+<p>Release happens on <time datetime="+2024-04-15T08:00:00Z">+2024-04-15 08:00 Z</time>.</p>

--- a/test/html5/nesting_and_inlines.hdoc
+++ b/test/html5/nesting_and_inlines.hdoc
@@ -1,0 +1,21 @@
+hdoc(version="2.0", title="Nesting and Inlines", lang="en");
+
+h1(id="top") "Nesting and Inline Styling"
+
+p "This document exercises inline formatting and nested lists."
+
+p { We can mix \em{emphasis}, \strike{strike}, \mono{monospace} text. Superscript x\sup{2} and subscript x\sub{2} also appear. }
+
+p { Links point to \link(ref="top"){local anchors} or \link(uri="https://example.com"){external sites}. }
+
+ul {
+  li { p "Top-level item one" }
+  li {
+    p "Top-level item two with nested list"
+    ol(first="1") {
+      li "Nested ordered item A"
+      li "Nested ordered item B"
+    }
+  }
+  li { p "Top-level item three" }
+}

--- a/test/html5/nesting_and_inlines.html
+++ b/test/html5/nesting_and_inlines.html
@@ -1,0 +1,23 @@
+<h1 id="top">Nesting and Inline Styling</h1>
+<p>This document exercises inline formatting and nested lists.</p>
+<p>We can mix <em>emphasis</em>, <s>strike</s>, <code class="hdoc-code">monospace</code>text. Superscript x<sup>2</sup>and subscript x<sub>2</sub>also appear.</p>
+<p>Links point to <a href="#top">local anchors</a>or <a href="https://example.com">external sites</a>.</p>
+<ul>
+  <li>
+    <p>Top-level item one</p>
+  </li>
+  <li>
+    <p>Top-level item two with nested list</p>
+    <ol start="1">
+      <li>
+        <p>Nested ordered item A</p>
+      </li>
+      <li>
+        <p>Nested ordered item B</p>
+      </li>
+    </ol>
+  </li>
+  <li>
+    <p>Top-level item three</p>
+  </li>
+</ul>

--- a/test/html5/paragraph_styles.hdoc
+++ b/test/html5/paragraph_styles.hdoc
@@ -1,0 +1,17 @@
+hdoc(version="2.0", title="Paragraph Styles", lang="en");
+
+h1 "Paragraph Styles"
+
+p "A standard paragraph introducing the styles below."
+
+note "Notes provide informational context without urgency."
+
+warning "Warnings highlight potential issues to watch for."
+
+danger "Danger blocks signal critical problems."
+
+tip "Tips offer helpful hints for readers."
+
+quote "Quoted material sits in its own paragraph style."
+
+spoiler "This is a spoiler; renderers may hide or blur this content."

--- a/test/html5/paragraph_styles.html
+++ b/test/html5/paragraph_styles.html
@@ -1,0 +1,8 @@
+<h1 id="hdoc-auto-0">Paragraph Styles</h1>
+<p>A standard paragraph introducing the styles below.</p>
+<p class="hdoc-note">Notes provide informational context without urgency.</p>
+<p class="hdoc-warning">Warnings highlight potential issues to watch for.</p>
+<p class="hdoc-danger">Danger blocks signal critical problems.</p>
+<p class="hdoc-tip">Tips offer helpful hints for readers.</p>
+<p class="hdoc-quote">Quoted material sits in its own paragraph style.</p>
+<p class="hdoc-spoiler">This is a spoiler; renderers may hide or blur this content.</p>

--- a/test/html5/tables.hdoc
+++ b/test/html5/tables.hdoc
@@ -1,0 +1,28 @@
+hdoc(version="2.0", title="Tables", lang="en");
+
+h1 "Table Coverage"
+
+p "This file covers header rows, data rows with titles, groups, and colspans."
+
+table {
+  columns {
+    td { p "Column A" }
+    td { p "Column B" }
+    td { p "Column C" }
+  }
+  group { "Section One" }
+  row(title="Row 1") {
+    td { p "A1" }
+    td(colspan="2") { p "B1-C1" }
+  }
+  row(title="Row 2") {
+    td(colspan="2") { p "A2-B2" }
+    td { p "C2" }
+  }
+  group { "Section Two" }
+  row(title="Row 3") {
+    td { p "A3" }
+    td { p "B3" }
+    td { p "C3" }
+  }
+}

--- a/test/html5/tables.html
+++ b/test/html5/tables.html
@@ -1,0 +1,58 @@
+<h1 id="hdoc-auto-0">Table Coverage</h1>
+<p>This file covers header rows, data rows with titles, groups, and colspans.</p>
+<table>
+  <thead>
+    <tr>
+      <th scope="col"></th>
+      <th scope="col">
+        <p>Column A</p>
+      </th>
+      <th scope="col">
+        <p>Column B</p>
+      </th>
+      <th scope="col">
+        <p>Column C</p>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td></td>
+      <th scope="colgroup" colspan="3">&quot;Section One&quot;</th>
+    </tr>
+    <tr>
+      <th scope="row">Row 1</th>
+      <td>
+        <p>A1</p>
+      </td>
+      <td colspan="2">
+        <p>B1-C1</p>
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Row 2</th>
+      <td colspan="2">
+        <p>A2-B2</p>
+      </td>
+      <td>
+        <p>C2</p>
+      </td>
+    </tr>
+    <tr>
+      <td></td>
+      <th scope="colgroup" colspan="3">&quot;Section Two&quot;</th>
+    </tr>
+    <tr>
+      <th scope="row">Row 3</th>
+      <td>
+        <p>A3</p>
+      </td>
+      <td>
+        <p>B3</p>
+      </td>
+      <td>
+        <p>C3</p>
+      </td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
## Summary
- normalize TOC handling and table rendering so empty lists are suppressed and col/colgroup scopes follow accessibility expectations
- fix datetime formatting to avoid buffer aliasing and keep HTML output stable
- add and refresh HTML5 golden fixtures (paragraph styles, nesting/inlines, tables, media/TOC) with maintenance notes

## Testing
- zig build
- ./zig-out/bin/hyperdoc test/html5/paragraph_styles.hdoc > test/html5/paragraph_styles.html
- ./zig-out/bin/hyperdoc test/html5/nesting_and_inlines.hdoc > test/html5/nesting_and_inlines.html
- ./zig-out/bin/hyperdoc test/html5/tables.hdoc > test/html5/tables.html
- ./zig-out/bin/hyperdoc test/html5/media_and_toc.hdoc > test/html5/media_and_toc.html
- zig build test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695457b76c7c832292bb29fc43d127d7)