### PR TITLE
Enforce top-level toc

### DIFF
--- a/src/hyperdoc.zig
+++ b/src/hyperdoc.zig
@@ -1316,6 +1316,11 @@ pub const SemanticAnalyzer = struct {
                 try blocks.ensureTotalCapacityPrecise(sema.arena, child_nodes.len);
 
                 for (child_nodes) |child_node| {
+                    if (child_node.type == .toc) {
+                        try sema.emit_diagnostic(.illegal_child_item, child_node.location);
+                        continue;
+                    }
+
                     const block, const id = try sema.translate_block_node(child_node);
                     if (id != null) {
                         try sema.emit_diagnostic(.illegal_id_attribute, get_attribute_location(child_node, "id", .name).?);

--- a/src/testsuite.zig
+++ b/src/testsuite.zig
@@ -604,6 +604,7 @@ test "diagnostic codes are emitted for expected samples" {
     try validateDiagnostics(.{}, "hdoc(version=\"2.0\",lang=\"en\"); hdoc(version=\"2.0\",lang=\"en\");", &.{ .misplaced_hdoc_header, .duplicate_hdoc_header });
     try validateDiagnostics(.{}, "hdoc(version=\"2.0\",lang=\"en\"); h1 \"bad\\q\"", &.{.{ .invalid_string_escape = .{ .codepoint = 'q' } }});
     try validateDiagnostics(.{}, "hdoc(version=\"2.0\",lang=\"en\"); h1 \"bad\\u{9}\"", &.{.{ .illegal_character = .{ .codepoint = 0x9 } }});
+    try validateDiagnostics(.{}, "hdoc(version=\"2.0\",lang=\"en\"); ul{ li{ toc; } }", &.{.illegal_child_item});
 }
 
 test "title block populates metadata and warns on inline date" {


### PR DESCRIPTION
## Summary
- emit diagnostics when toc appears in nested block lists, keeping toc restricted to top-level usage
- add a regression test covering illegal toc placement

## Testing
- zig build test
- zig build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695851a623648322a39aaf8197dd6ce8)