### PR TITLE
Validate table column structure

### DIFF
--- a/src/hyperdoc.zig
+++ b/src/hyperdoc.zig
@@ -118,8 +118,8 @@ pub const Block = union(enum) {
     };
 
     pub const Table = struct {
-        // TODO: column_count: usize,
-        // TODO: has_row_titles: bool, // not counted inside `Table.column_count`!
+        column_count: usize,
+        has_row_titles: bool, // not counted inside `Table.column_count`!
         lang: LanguageTag,
         rows: []TableRow,
     };
@@ -1138,7 +1138,10 @@ pub const SemanticAnalyzer = struct {
         var rows: std.ArrayList(Block.TableRow) = .empty;
         defer rows.deinit(sema.arena);
 
-        var column_count: ?usize = null;
+        var column_count: usize = 0;
+        var saw_header_row = false;
+        var saw_non_header_row = false;
+        var has_row_titles = false;
 
         switch (node.body) {
             .list => |child_nodes| {
@@ -1146,39 +1149,43 @@ pub const SemanticAnalyzer = struct {
                 for (child_nodes) |child_node| {
                     switch (child_node.type) {
                         .columns => {
+                            if (saw_header_row) {
+                                try sema.emit_diagnostic(.duplicate_columns_row, child_node.location);
+                            }
+
+                            if (saw_non_header_row) {
+                                try sema.emit_diagnostic(.misplaced_columns_row, child_node.location);
+                            }
+
+                            saw_header_row = true;
+
                             const row_attrs = try sema.get_attributes(child_node, struct {
                                 lang: LanguageTag = .inherit,
                             });
 
                             const cells = try sema.translate_table_cells(child_node);
+                            const width = calculate_table_width(cells);
+                            try sema.update_table_column_count(&column_count, width, child_node.location);
+
                             rows.appendAssumeCapacity(.{
                                 .columns = .{
                                     .lang = row_attrs.lang,
                                     .cells = cells,
                                 },
                             });
-
-                            var width: usize = 0;
-                            for (cells) |cell| {
-                                std.debug.assert(cell.colspan > 0);
-                                width += cell.colspan;
-                            }
-
-                            column_count = column_count orelse width;
-                            if (width != column_count) {
-                                try sema.emit_diagnostic(.{ .column_count_mismatch = .{
-                                    .expected = column_count.?,
-                                    .actual = width,
-                                } }, child_node.location);
-                            }
                         },
                         .row => {
+                            saw_non_header_row = true;
+
                             const row_attrs = try sema.get_attributes(child_node, struct {
                                 lang: LanguageTag = .inherit,
                                 title: ?[]const u8 = null,
                             });
 
                             const cells = try sema.translate_table_cells(child_node);
+                            const width = calculate_table_width(cells);
+                            try sema.update_table_column_count(&column_count, width, child_node.location);
+                            has_row_titles = has_row_titles or (row_attrs.title != null);
 
                             rows.appendAssumeCapacity(.{
                                 .row = .{
@@ -1187,22 +1194,10 @@ pub const SemanticAnalyzer = struct {
                                     .cells = cells,
                                 },
                             });
-
-                            var width: usize = 0;
-                            for (cells) |cell| {
-                                std.debug.assert(cell.colspan > 0);
-                                width += cell.colspan;
-                            }
-
-                            column_count = column_count orelse width;
-                            if (width != column_count) {
-                                try sema.emit_diagnostic(.{ .column_count_mismatch = .{
-                                    .expected = column_count.?,
-                                    .actual = width,
-                                } }, child_node.location);
-                            }
                         },
                         .group => {
+                            saw_non_header_row = true;
+
                             const row_attrs = try sema.get_attributes(child_node, struct {
                                 lang: LanguageTag = .inherit,
                             });
@@ -1225,12 +1220,52 @@ pub const SemanticAnalyzer = struct {
             },
         }
 
+        if (column_count == 0) {
+            try sema.emit_diagnostic(.missing_table_column_count, node.location);
+            column_count = 1;
+        }
+
         const table: Block.Table = .{
+            .column_count = column_count,
+            .has_row_titles = has_row_titles,
             .lang = attrs.lang,
             .rows = try rows.toOwnedSlice(sema.arena),
         };
 
         return .{ table, attrs.id };
+    }
+
+    fn calculate_table_width(cells: []const Block.TableCell) usize {
+        var width: usize = 0;
+        for (cells) |cell| {
+            std.debug.assert(cell.colspan > 0);
+            width += cell.colspan;
+        }
+        return width;
+    }
+
+    fn update_table_column_count(sema: *SemanticAnalyzer, column_count: *usize, width: usize, location: Parser.Location) !void {
+        if (width == 0) {
+            if (column_count.* != 0) {
+                try sema.emit_diagnostic(.{ .column_count_mismatch = .{
+                    .expected = column_count.*,
+                    .actual = 0,
+                } }, location);
+            }
+            return;
+        }
+
+        if (column_count.* == 0) {
+            column_count.* = width;
+            return;
+        }
+
+        if (width != column_count.*) {
+            try sema.emit_diagnostic(.{ .column_count_mismatch = .{
+                .expected = column_count.*,
+                .actual = width,
+            } }, location);
+        }
     }
 
     fn translate_table_cells(sema: *SemanticAnalyzer, node: Parser.Node) error{ OutOfMemory, BadAttributes, InvalidNodeType, Unimplemented }![]Block.TableCell {
@@ -3208,6 +3243,9 @@ pub const Diagnostic = struct {
         misplaced_title_block,
         duplicate_title_block,
         column_count_mismatch: TableShapeError,
+        missing_table_column_count,
+        misplaced_columns_row,
+        duplicate_columns_row,
         duplicate_id: ReferenceError,
         unknown_id: ReferenceError,
 
@@ -3262,6 +3300,9 @@ pub const Diagnostic = struct {
                 .misplaced_title_block,
                 .duplicate_title_block,
                 .column_count_mismatch,
+                .missing_table_column_count,
+                .misplaced_columns_row,
+                .duplicate_columns_row,
                 .duplicate_id,
                 .unknown_id,
                 => .@"error",
@@ -3353,6 +3394,9 @@ pub const Diagnostic = struct {
                 .invalid_date_time_body => try w.writeAll("\\date, \\time and \\datetime do not allow any inlines inside their body."),
 
                 .column_count_mismatch => |ctx| try w.print("Expected {} columns, but found {}", .{ ctx.expected, ctx.actual }),
+                .missing_table_column_count => try w.writeAll("Table must declare at least one column via a columns or row entry."),
+                .misplaced_columns_row => try w.writeAll("The 'columns' header row must be the first item in a table."),
+                .duplicate_columns_row => try w.writeAll("Only one 'columns' header row is allowed per table."),
 
                 .duplicate_id => |ctx| try w.print("The id \"{s}\" is already taken by another node.", .{ctx.ref}),
                 .unknown_id => |ctx| try w.print("The referenced id \"{s}\" does not exist.", .{ctx.ref}),

--- a/src/render/dump.zig
+++ b/src/render/dump.zig
@@ -440,6 +440,8 @@ fn dumpBlockInline(writer: *Writer, indent: usize, block: hdoc.Block) Writer.Err
         .table => |table| {
             try writeTypeTag(writer, "table");
             try dumpOptionalStringField(writer, indent + indent_step, "lang", table.lang.text);
+            try dumpOptionalNumberField(writer, indent + indent_step, "column_count", @as(?usize, table.column_count));
+            try dumpBoolField(writer, indent + indent_step, "has_row_titles", table.has_row_titles);
             try dumpTableRowsField(writer, indent + indent_step, "rows", table.rows);
         },
     }

--- a/src/render/html5.zig
+++ b/src/render/html5.zig
@@ -301,8 +301,8 @@ const RenderContext = struct {
         const lang_attr = langAttribute(table.lang);
         const id_attr = ctx.resolveBlockId(block_index);
 
-        const column_count = inferColumnCount(table.rows) orelse 0;
-        const has_title_column = tableHasTitleColumn(table.rows);
+        const column_count = table.column_count;
+        const has_title_column = table.has_row_titles;
 
         try writeIndent(ctx.writer, indent);
         try writeStartTag(ctx.writer, "table", .regular, .{ .id = id_attr, .lang = lang_attr });
@@ -707,44 +707,8 @@ fn tocHasEntries(node: hdoc.Document.TableOfContents) bool {
     return false;
 }
 
-fn inferColumnCount(rows: []const hdoc.Block.TableRow) ?usize {
-    for (rows) |row| {
-        switch (row) {
-            .columns => |columns| {
-                var width: usize = 0;
-                for (columns.cells) |cell| {
-                    width += cell.colspan;
-                }
-                return width;
-            },
-            .row => |data_row| {
-                var width: usize = 0;
-                for (data_row.cells) |cell| {
-                    width += cell.colspan;
-                }
-                return width;
-            },
-            .group => {},
-        }
-    }
-    return null;
-}
-
-fn tableHasTitleColumn(rows: []const hdoc.Block.TableRow) bool {
-    for (rows) |row| {
-        switch (row) {
-            .row => |data_row| if (data_row.title != null) return true,
-            .group => return true,
-            .columns => {},
-        }
-    }
-    return false;
-}
-
 fn findHeaderIndex(rows: []const hdoc.Block.TableRow) ?usize {
-    for (rows, 0..) |row, index| {
-        if (row == .columns) return index;
-    }
+    if (rows.len > 0 and rows[0] == .columns) return 0;
     return null;
 }
 

--- a/src/testsuite.zig
+++ b/src/testsuite.zig
@@ -606,6 +606,89 @@ test "diagnostic codes are emitted for expected samples" {
     try validateDiagnostics(.{}, "hdoc(version=\"2.0\",lang=\"en\"); h1 \"bad\\u{9}\"", &.{.{ .illegal_character = .{ .codepoint = 0x9 } }});
 }
 
+test "table derives column count from first data row" {
+    const code =
+        \\hdoc(version="2.0",lang="en");
+        \\table {
+        \\  row(title="headered") {
+        \\    td { p "A" }
+        \\    td(colspan="2") { p "B" }
+        \\  }
+        \\}
+    ;
+
+    var diagnostics: hdoc.Diagnostics = .init(std.testing.allocator);
+    defer diagnostics.deinit();
+
+    var doc = try hdoc.parse(std.testing.allocator, code, &diagnostics);
+    defer doc.deinit();
+
+    try std.testing.expect(!diagnostics.has_error());
+    try std.testing.expectEqual(@as(usize, 1), doc.contents.len);
+
+    switch (doc.contents[0]) {
+        .table => |table| {
+            try std.testing.expectEqual(@as(usize, 3), table.column_count);
+            try std.testing.expect(table.has_row_titles);
+        },
+        else => return error.TestExpectedEqual,
+    }
+}
+
+test "table without header or data rows is rejected" {
+    try validateDiagnostics(.{}, "hdoc(version=\"2.0\",lang=\"en\"); table { group \"Topic\" }", &.{.missing_table_column_count});
+}
+
+test "columns row must come first" {
+    const code =
+        \\hdoc(version="2.0",lang="en");
+        \\table {
+        \\  row { td "A" }
+        \\  columns { td "B" }
+        \\}
+    ;
+
+    try validateDiagnostics(.{}, code, &.{.misplaced_columns_row});
+}
+
+test "table allows only one columns row" {
+    const code =
+        \\hdoc(version="2.0",lang="en");
+        \\table {
+        \\  columns { td "A" }
+        \\  columns { td "B" }
+        \\}
+    ;
+
+    try validateDiagnostics(.{}, code, &.{.duplicate_columns_row});
+}
+
+test "table tracks presence of row titles" {
+    const code =
+        \\hdoc(version="2.0",lang="en");
+        \\table {
+        \\  row { td "A" }
+        \\  group { "Topic" }
+        \\}
+    ;
+
+    var diagnostics: hdoc.Diagnostics = .init(std.testing.allocator);
+    defer diagnostics.deinit();
+
+    var doc = try hdoc.parse(std.testing.allocator, code, &diagnostics);
+    defer doc.deinit();
+
+    try std.testing.expect(!diagnostics.has_error());
+    try std.testing.expectEqual(@as(usize, 1), doc.contents.len);
+
+    switch (doc.contents[0]) {
+        .table => |table| {
+            try std.testing.expect(!table.has_row_titles);
+        },
+        else => return error.TestExpectedEqual,
+    }
+}
+
 test "title block populates metadata and warns on inline date" {
     const code = "hdoc(version=\"2.0\",lang=\"en\");\ntitle { Hello \\date{2020-01-02} }\nh1 \"Body\"";
 


### PR DESCRIPTION
## Summary
- enforce a single optional leading `columns` row and record the effective column count for tables
- validate column counts when header rows are missing or widths disagree, and track whether tables include row titles
- expose table column metadata to renderers/dump output and add regression tests for table layouts and row-title detection

## Testing
- zig build test
- zig build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695851908c308322a9879404f42a5d11)