### PR TITLE
Handle admonition block containers

### DIFF
--- a/examples/demo.hdoc
+++ b/examples/demo.hdoc
@@ -21,12 +21,12 @@ p {
 
 h2{Special Paragraphs}
 
-note    { HyperDoc 2.0 also supports different types of paragraphs. }
-warning { These should affect rendering, and have well-defined semantics attached to them. }
-danger  { You shall not assume any specific formatting of these elements though. }
-tip     { They typically have a standardized style though. }
-quote   { You shall not pass! }
-spoiler { Nobody expects the Spanish Inquisition! }
+note "HyperDoc 2.0 also supports different types of paragraphs."
+warning "These should affect rendering, and have well-defined semantics attached to them."
+danger "You shall not assume any specific formatting of these elements though."
+tip "They typically have a standardized style though."
+quote "You shall not pass!"
+spoiler "Nobody expects the Spanish Inquisition!"
 
 h2{Verbatim and Preformatted Text}
 

--- a/examples/guide.hdoc
+++ b/examples/guide.hdoc
@@ -24,12 +24,12 @@ p {
   Links can target \link(ref="fig-diagram"){other blocks} or external \link(uri="https://ashet.computer"){resources}.
 }
 
-note    { Notes highlight supportive information. }
-warning { Warnings call out risky behavior. }
-danger  { Danger paragraphs emphasize critical hazards. }
-tip     { Tips provide actionable hints. }
-quote   { Quotes include sourced or emphasized wording. }
-spoiler { Spoilers hide key story information until revealed. }
+note "Notes highlight supportive information."
+warning "Warnings call out risky behavior."
+danger "Danger paragraphs emphasize critical hazards."
+tip "Tips provide actionable hints."
+quote "Quotes include sourced or emphasized wording."
+spoiler "Spoilers hide key story information until revealed."
 
 h2(id="literals") { Literal and Preformatted Blocks }
 

--- a/src/hyperdoc.zig
+++ b/src/hyperdoc.zig
@@ -50,6 +50,7 @@ pub const Document = struct {
 pub const Block = union(enum) {
     heading: Heading,
     paragraph: Paragraph,
+    admonition: Admonition,
     list: List,
     image: Image,
     preformatted: Preformatted,
@@ -81,12 +82,17 @@ pub const Block = union(enum) {
     };
 
     pub const Paragraph = struct {
-        kind: ParagraphKind,
         lang: LanguageTag,
         content: []Span,
     };
 
-    pub const ParagraphKind = enum { p, note, warning, danger, tip, quote, spoiler };
+    pub const Admonition = struct {
+        kind: AdmonitionKind,
+        lang: LanguageTag,
+        content: []Block,
+    };
+
+    pub const AdmonitionKind = enum { note, warning, danger, tip, quote, spoiler };
 
     pub const List = struct {
         lang: LanguageTag,
@@ -880,9 +886,13 @@ pub const SemanticAnalyzer = struct {
                 const heading, const id = try sema.translate_heading_node(node);
                 return .{ .{ .heading = heading }, id };
             },
-            .p, .note, .warning, .danger, .tip, .quote, .spoiler => {
+            .p => {
                 const paragraph, const id = try sema.translate_paragraph_node(node);
                 return .{ .{ .paragraph = paragraph }, id };
+            },
+            .note, .warning, .danger, .tip, .quote, .spoiler => {
+                const admonition, const id = try sema.translate_admonition_node(node);
+                return .{ .{ .admonition = admonition }, id };
             },
             .ul, .ol => {
                 const list, const id = try sema.translate_list_node(node);
@@ -976,8 +986,21 @@ pub const SemanticAnalyzer = struct {
         });
 
         const heading: Block.Paragraph = .{
+            .lang = attrs.lang,
+            .content = try sema.translate_inline(node, .emit_diagnostic, .one_space),
+        };
+
+        return .{ heading, attrs.id };
+    }
+
+    fn translate_admonition_node(sema: *SemanticAnalyzer, node: Parser.Node) !struct { Block.Admonition, ?Reference } {
+        const attrs = try sema.get_attributes(node, struct {
+            lang: LanguageTag = .inherit,
+            id: ?Reference = null,
+        });
+
+        const admonition: Block.Admonition = .{
             .kind = switch (node.type) {
-                .p => .p,
                 .note => .note,
                 .warning => .warning,
                 .danger => .danger,
@@ -987,10 +1010,10 @@ pub const SemanticAnalyzer = struct {
                 else => unreachable,
             },
             .lang = attrs.lang,
-            .content = try sema.translate_inline(node, .emit_diagnostic, .one_space),
+            .content = try sema.translate_block_list(node, .text_to_p),
         };
 
-        return .{ heading, attrs.id };
+        return .{ admonition, attrs.id };
     }
 
     fn translate_list_node(sema: *SemanticAnalyzer, node: Parser.Node) !struct { Block.List, ?Reference } {
@@ -1337,7 +1360,6 @@ pub const SemanticAnalyzer = struct {
                     const blocks = try sema.arena.alloc(Block, 1);
                     blocks[0] = .{
                         .paragraph = .{
-                            .kind = .p,
                             .lang = .inherit,
                             .content = spans,
                         },
@@ -3079,12 +3101,6 @@ pub const Parser = struct {
 
                 .title,
                 .p,
-                .note,
-                .warning,
-                .danger,
-                .tip,
-                .quote,
-                .spoiler,
 
                 .img,
                 .pre,
@@ -3106,6 +3122,12 @@ pub const Parser = struct {
                 => true,
 
                 .hdoc,
+                .note,
+                .warning,
+                .danger,
+                .tip,
+                .quote,
+                .spoiler,
                 .ul,
                 .ol,
                 .table,

--- a/src/render/dump.zig
+++ b/src/render/dump.zig
@@ -409,9 +409,14 @@ fn dumpBlockInline(writer: *Writer, indent: usize, block: hdoc.Block) Writer.Err
         },
         .paragraph => |paragraph| {
             try writeTypeTag(writer, "paragraph");
-            try dumpEnumField(writer, indent + indent_step, "kind", paragraph.kind);
             try dumpOptionalStringField(writer, indent + indent_step, "lang", paragraph.lang.text);
             try dumpSpanListField(writer, indent + indent_step, "content", paragraph.content);
+        },
+        .admonition => |admonition| {
+            try writeTypeTag(writer, "admonition");
+            try dumpEnumField(writer, indent + indent_step, "kind", admonition.kind);
+            try dumpOptionalStringField(writer, indent + indent_step, "lang", admonition.lang.text);
+            try dumpBlockListField(writer, indent + indent_step, "content", admonition.content);
         },
         .list => |list| {
             try writeTypeTag(writer, "list");

--- a/src/render/html5.zig
+++ b/src/render/html5.zig
@@ -26,6 +26,7 @@ const RenderContext = struct {
         switch (block) {
             .heading => |heading| try ctx.renderHeading(heading, block_index, indent),
             .paragraph => |paragraph| try ctx.renderParagraph(paragraph, block_index, indent),
+            .admonition => |admonition| try ctx.renderAdmonition(admonition, block_index, indent),
             .list => |list| try ctx.renderList(list, block_index, indent),
             .image => |image| try ctx.renderImage(image, block_index, indent),
             .preformatted => |preformatted| try ctx.renderPreformatted(preformatted, block_index, indent),
@@ -127,20 +128,35 @@ const RenderContext = struct {
         const lang_attr = langAttribute(paragraph.lang);
         const id_attr = ctx.resolveBlockId(block_index);
 
-        var class_buffer: [32]u8 = undefined;
-        const class_attr: ?[]const u8 = switch (paragraph.kind) {
-            .p => null,
-            else => std.fmt.bufPrint(&class_buffer, "hdoc-{s}", .{@tagName(paragraph.kind)}) catch unreachable,
-        };
-
         try writeIndent(ctx.writer, indent);
         try writeStartTag(ctx.writer, "p", .regular, .{
             .id = id_attr,
             .lang = lang_attr,
-            .class = class_attr,
         });
         try ctx.renderSpans(paragraph.content);
         try writeEndTag(ctx.writer, "p");
+        try ctx.writer.writeByte('\n');
+    }
+
+    fn renderAdmonition(ctx: *RenderContext, admonition: hdoc.Block.Admonition, block_index: ?usize, indent: usize) RenderError!void {
+        const lang_attr = langAttribute(admonition.lang);
+        const id_attr = ctx.resolveBlockId(block_index);
+
+        var class_buffer: [32]u8 = undefined;
+        const class_attr = std.fmt.bufPrint(&class_buffer, "hdoc-{s}", .{@tagName(admonition.kind)}) catch unreachable;
+
+        try writeIndent(ctx.writer, indent);
+        try writeStartTag(ctx.writer, "div", .regular, .{
+            .id = id_attr,
+            .lang = lang_attr,
+            .class = class_attr,
+        });
+        if (admonition.content.len > 0) {
+            try ctx.writer.writeByte('\n');
+            try ctx.renderBlocks(admonition.content, indent + indent_step);
+            try writeIndent(ctx.writer, indent);
+        }
+        try writeEndTag(ctx.writer, "div");
         try ctx.writer.writeByte('\n');
     }
 

--- a/src/testsuite.zig
+++ b/src/testsuite.zig
@@ -224,6 +224,84 @@ test "span merger preserves whitespace after inline mono" {
     }
 }
 
+test "admonition supports block-list bodies" {
+    var diagnostics: hdoc.Diagnostics = .init(std.testing.allocator);
+    defer diagnostics.deinit();
+
+    const source =
+        \\hdoc(version="2.0",lang="en");
+        \\note{
+        \\  p "Outer block text."
+        \\  ul{li "Nested item"}
+        \\}
+    ;
+
+    var doc = try hdoc.parse(std.testing.allocator, source, &diagnostics);
+    defer doc.deinit();
+
+    try std.testing.expect(!diagnostics.has_error());
+    try std.testing.expectEqual(@as(usize, 1), doc.contents.len);
+
+    const admonition = doc.contents[0].admonition;
+    try std.testing.expectEqual(hdoc.Block.AdmonitionKind.note, admonition.kind);
+    try std.testing.expectEqual(@as(usize, 2), admonition.content.len);
+
+    switch (admonition.content[0]) {
+        .paragraph => |para| {
+            try std.testing.expectEqual(@as(usize, 1), para.content.len);
+            try std.testing.expectEqualStrings("Outer block text.", para.content[0].content.text);
+        },
+        else => return error.TestExpectedEqual,
+    }
+
+    switch (admonition.content[1]) {
+        .list => |list| {
+            try std.testing.expectEqual(@as(usize, 1), list.items.len);
+            try std.testing.expectEqual(@as(?u32, null), list.first);
+            try std.testing.expectEqual(@as(usize, 1), list.items[0].content.len);
+        },
+        else => return error.TestExpectedEqual,
+    }
+}
+
+test "admonition shorthand promotes inline bodies to paragraphs" {
+    var diagnostics: hdoc.Diagnostics = .init(std.testing.allocator);
+    defer diagnostics.deinit();
+
+    const source =
+        "hdoc(version=\"2.0\",lang=\"en\");\n" ++
+        "warning \"Be careful.\" \n" ++
+        "tip:\n" ++
+        "| first line\n" ++
+        "| second line\n";
+
+    var doc = try hdoc.parse(std.testing.allocator, source, &diagnostics);
+    defer doc.deinit();
+
+    try std.testing.expect(!diagnostics.has_error());
+    try std.testing.expectEqual(@as(usize, 2), doc.contents.len);
+
+    const warning_block = doc.contents[0].admonition;
+    try std.testing.expectEqual(hdoc.Block.AdmonitionKind.warning, warning_block.kind);
+    try std.testing.expectEqual(@as(usize, 1), warning_block.content.len);
+    switch (warning_block.content[0]) {
+        .paragraph => |para| {
+            try std.testing.expectEqualStrings("Be careful.", para.content[0].content.text);
+        },
+        else => return error.TestExpectedEqual,
+    }
+
+    const tip_block = doc.contents[1].admonition;
+    try std.testing.expectEqual(hdoc.Block.AdmonitionKind.tip, tip_block.kind);
+    try std.testing.expectEqual(@as(usize, 1), tip_block.content.len);
+    switch (tip_block.content[0]) {
+        .paragraph => |para| {
+            try std.testing.expectEqualStrings("first line\nsecond line", para.content[0].content.text);
+        },
+        else => return error.TestExpectedEqual,
+    }
+}
+
 test "pre verbatim preserves trailing whitespace" {
     var diagnostics: hdoc.Diagnostics = .init(std.testing.allocator);
     defer diagnostics.deinit();

--- a/test/html5/admonition_blocks.hdoc
+++ b/test/html5/admonition_blocks.hdoc
@@ -1,0 +1,17 @@
+hdoc(version="2.0", title="Admonition Blocks", lang="en");
+
+h1 "Admonitions as Containers"
+
+note{
+  p "A note can span multiple blocks."
+  ul{
+    li "Lists are allowed."
+    li "They render inside the note container."
+  }
+}
+
+danger "String bodies become paragraphs inside the container."
+
+spoiler:
+| Hidden detail
+| spans multiple lines.

--- a/test/html5/admonition_blocks.html
+++ b/test/html5/admonition_blocks.html
@@ -1,0 +1,22 @@
+<header lang="en">
+  <h1 lang="en">Admonition Blocks</h1>
+</header>
+<h2 id="hdoc-auto-0">§1 Admonitions as Containers</h2>
+<div class="hdoc-note">
+  <p>A note can span multiple blocks.</p>
+  <ul>
+    <li>
+      <p>Lists are allowed.</p>
+    </li>
+    <li>
+      <p>They render inside the note container.</p>
+    </li>
+  </ul>
+</div>
+<div class="hdoc-danger">
+  <p>String bodies become paragraphs inside the container.</p>
+</div>
+<div class="hdoc-spoiler">
+  <p>Hidden detail
+spans multiple lines.</p>
+</div>

--- a/test/html5/paragraph_styles.html
+++ b/test/html5/paragraph_styles.html
@@ -3,9 +3,21 @@
 </header>
 <h2 id="hdoc-auto-0">§1 Paragraph Styles</h2>
 <p>A standard paragraph introducing the styles below.</p>
-<p class="hdoc-note">Notes provide informational context without urgency.</p>
-<p class="hdoc-warning">Warnings highlight potential issues to watch for.</p>
-<p class="hdoc-danger">Danger blocks signal critical problems.</p>
-<p class="hdoc-tip">Tips offer helpful hints for readers.</p>
-<p class="hdoc-quote">Quoted material sits in its own paragraph style.</p>
-<p class="hdoc-spoiler">This is a spoiler; renderers may hide or blur this content.</p>
+<div class="hdoc-note">
+  <p>Notes provide informational context without urgency.</p>
+</div>
+<div class="hdoc-warning">
+  <p>Warnings highlight potential issues to watch for.</p>
+</div>
+<div class="hdoc-danger">
+  <p>Danger blocks signal critical problems.</p>
+</div>
+<div class="hdoc-tip">
+  <p>Tips offer helpful hints for readers.</p>
+</div>
+<div class="hdoc-quote">
+  <p>Quoted material sits in its own paragraph style.</p>
+</div>
+<div class="hdoc-spoiler">
+  <p>This is a spoiler; renderers may hide or blur this content.</p>
+</div>


### PR DESCRIPTION
## Summary
- treat admonition blocks as block-list containers and promote inline bodies into paragraphs for shorthand cases
- render admonitions as container elements in both HTML and dump outputs
- remove the now-unused paragraph kind field and keep paragraph handling simple
- add regression coverage and fixtures for the new admonition behavior and update examples to match

## Testing
- zig build
- zig build test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69585162aa788322b68238fbb79ce2e2)