### PR TITLE
Render empty-body references with heading formatting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 - Run `zig build` to validate the main application still compiles
 - Test `./zig-out/bin/hyperdoc` with the `.hdoc` files in `examples/` and `test/`.
 - Avoid editing documentation unless the request explicitly asks for it.
+- `src/hyperdoc.zig` must not contain locale- or rendering-specific parts.
 - Treat `docs/specification.md` as the authoritative source of behavior; examples may be outdated or incorrect.
 - If the spec is unclear or conflicts with code/tests, ask before changing behavior.
 - Do not implement "just make it work" fallbacks that alter semantics to satisfy examples.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -812,6 +812,7 @@ Notes:
 Semantics:
 
 - `\ref(ref="X")` **MUST** resolve to a top-level element with `id="X"`, otherwise it is semantically invalid.
+- A `\ref` inline element **MUST NOT** appear inside `h1`, `h2`, `h3`, or `title` elements.
 - If `\ref` has a non-empty body, the body **MUST** be used as the rendered link text.
 - If `\ref` has an empty body (`;`), the following rules apply:
   - If the referenced target is a heading (`h1`, `h2`, `h3`), the renderer **MUST** synthesize link text from the target and `fmt`:

--- a/examples/demo.hdoc
+++ b/examples/demo.hdoc
@@ -15,7 +15,7 @@ p(id="foo") {
 p {
   This paragraph contains \em{inline} formatting. We don't support \strike{bold} or \strike{italic} as it's a stylistic choice.
   Other formatting we have is \mono{monospaced}, superscript (x\sup{2}) and subscript(x\sub{2}).
-  We can also \link(ref="foo"){link to other parts of a document} or \link(uri="https://ashet.computer"){to websites}.
+  We can also \ref(ref="foo"){link to other parts of a document} or \link(uri="https://ashet.computer"){to websites}.
   With \mono(syntax="c"){int *value = 10;} we can also have language information and potential syntax highlighting attached to monospaced font.
 }
 

--- a/examples/guide.hdoc
+++ b/examples/guide.hdoc
@@ -21,7 +21,7 @@ p {
 }
 
 p {
-  Links can target \link(ref="fig-diagram"){other blocks} or external \link(uri="https://ashet.computer"){resources}.
+  Links can target \ref(ref="fig-diagram"){other blocks} or external \link(uri="https://ashet.computer"){resources}.
 }
 
 note    { Notes highlight supportive information. }

--- a/src/hyperdoc.zig
+++ b/src/hyperdoc.zig
@@ -166,11 +166,20 @@ pub fn FormattedDateTime(comptime DT: type) type {
 }
 
 pub const Span = struct {
+    pub const ReferenceFormat = enum { full, name, index };
+
     pub const Content = union(enum) {
         text: []const u8,
         date: FormattedDateTime(Date),
         time: FormattedDateTime(Time),
         datetime: FormattedDateTime(DateTime),
+        reference: InlineReference,
+    };
+
+    pub const InlineReference = struct {
+        ref: Reference,
+        fmt: ReferenceFormat,
+        target_block: ?usize = null,
     };
 
     pub const Attributes = struct {
@@ -220,15 +229,24 @@ pub const ScriptPosition = enum {
 
 pub const Link = union(enum) {
     none,
-    ref: Reference,
+    ref: RefTarget,
     uri: Uri,
 
     pub fn eql(lhs: Link, rhs: Link) bool {
         return switch (lhs) {
             .none => (rhs == .none),
-            .ref => (rhs == .ref) and std.mem.eql(u8, lhs.ref.text, rhs.ref.text),
+            .ref => (rhs == .ref) and lhs.ref.eql(rhs.ref),
             .uri => (rhs == .uri) and std.mem.eql(u8, lhs.uri.text, rhs.uri.text),
         };
+    }
+};
+
+pub const RefTarget = struct {
+    ref: Reference,
+    block_index: ?usize = null,
+
+    pub fn eql(lhs: RefTarget, rhs: RefTarget) bool {
+        return lhs.ref.eql(rhs.ref) and lhs.block_index == rhs.block_index;
     }
 };
 
@@ -586,6 +604,7 @@ pub fn parse(
     }
 
     try sema.validate_references(&id_map);
+    try sema.resolve_references(&id_map);
 
     const doc_lang = header.lang orelse LanguageTag.inherit;
     const title = try sema.finalize_title(header, doc_lang);
@@ -920,6 +939,7 @@ pub const SemanticAnalyzer = struct {
             .@"\\sub",
             .@"\\sup",
             .@"\\link",
+            .@"\\ref",
             .@"\\time",
             .@"\\date",
             .@"\\datetime",
@@ -1415,6 +1435,12 @@ pub const SemanticAnalyzer = struct {
 
                     try merger.output.append(merger.arena, span);
                 },
+                .reference => {
+                    try merger.flush_internal(.keep);
+                    std.debug.assert(merger.current_span.items.len == 0);
+
+                    try merger.output.append(merger.arena, span);
+                },
                 .text => |text_content| {
                     std.debug.assert(span.attribs.eql(merger.attribs));
 
@@ -1594,34 +1620,44 @@ pub const SemanticAnalyzer = struct {
             .@"\\link" => {
                 const props = try sema.get_attributes(node, struct {
                     lang: LanguageTag = .inherit,
-                    uri: ?Uri = null,
-                    ref: ?Reference = null,
+                    uri: Uri,
                 });
-
-                if (props.uri != null and props.ref != null) {
-                    try sema.emit_diagnostic(.invalid_link, node.location);
-                }
-
-                const link: Link = if (props.uri) |uri| blk: {
-                    break :blk .{ .uri = uri };
-                } else if (props.ref) |ref| blk: {
-                    break :blk .{ .ref = ref };
-                } else blk: {
-                    try sema.emit_diagnostic(.invalid_link, node.location);
-                    break :blk .none;
-                };
-
-                if (props.ref) |ref| {
-                    if (props.uri == null) {
-                        const ref_location = get_attribute_location(node, "ref", .value) orelse node.location;
-                        try sema.pending_refs.append(sema.arena, .{ .ref = ref, .location = ref_location });
-                    }
-                }
 
                 try sema.translate_inline_body(spans, node.body, try sema.derive_attribute(node.location, attribs, .{
                     .lang = props.lang,
-                    .link = link,
+                    .link = .{ .uri = props.uri },
                 }), .emit_diagnostic);
+            },
+
+            .@"\\ref" => {
+                const props = try sema.get_attributes(node, struct {
+                    lang: LanguageTag = .inherit,
+                    ref: Reference,
+                    fmt: Span.ReferenceFormat = .full,
+                });
+
+                const ref_location = get_attribute_location(node, "ref", .value) orelse node.location;
+                try sema.pending_refs.append(sema.arena, .{ .ref = props.ref, .location = ref_location });
+
+                const link_attribs = try sema.derive_attribute(node.location, attribs, .{
+                    .lang = props.lang,
+                    .link = .{ .ref = .{ .ref = props.ref } },
+                });
+
+                switch (node.body) {
+                    .empty => {
+                        try spans.append(sema.arena, .{
+                            .content = .{ .reference = .{
+                                .ref = props.ref,
+                                .fmt = props.fmt,
+                                .target_block = null,
+                            } },
+                            .attribs = link_attribs,
+                            .location = node.location,
+                        });
+                    },
+                    else => try sema.translate_inline_body(spans, node.body, link_attribs, .emit_diagnostic),
+                }
             },
 
             .@"\\mono" => {
@@ -1665,6 +1701,7 @@ pub const SemanticAnalyzer = struct {
                 //  Convert the content_spans into a "rendered string".
                 const content_text = (sema.render_spans_to_plaintext(content_spans, .reject_date_time) catch |err| switch (err) {
                     error.DateTimeRenderingUnsupported => unreachable,
+                    error.UnexpectedReference => unreachable,
                     else => |e| return e,
                 }).text;
 
@@ -1777,7 +1814,7 @@ pub const SemanticAnalyzer = struct {
         sema: *SemanticAnalyzer,
         source_spans: []const Span,
         mode: PlaintextMode,
-    ) error{ OutOfMemory, DateTimeRenderingUnsupported }!TitlePlainText {
+    ) error{ OutOfMemory, DateTimeRenderingUnsupported, UnexpectedReference }!TitlePlainText {
         var output: std.ArrayList(u8) = .empty;
         defer output.deinit(sema.arena);
 
@@ -1786,6 +1823,7 @@ pub const SemanticAnalyzer = struct {
         for (source_spans) |span| {
             switch (span.content) {
                 .text => |str| try output.appendSlice(sema.arena, str),
+                .reference => return error.UnexpectedReference,
                 .date => |value| switch (mode) {
                     .reject_date_time => return error.DateTimeRenderingUnsupported,
                     .iso_date_time => {
@@ -1891,6 +1929,7 @@ pub const SemanticAnalyzer = struct {
         if (block_title) |title_block| {
             const rendered = sema.render_spans_to_plaintext(title_block.content, .iso_date_time) catch |err| switch (err) {
                 error.DateTimeRenderingUnsupported => unreachable,
+                error.UnexpectedReference => unreachable,
                 else => |e| return e,
             };
 
@@ -2099,7 +2138,10 @@ pub const SemanticAnalyzer = struct {
             LanguageTag => LanguageTag.parse(value) catch return error.InvalidValue,
             TimeZoneOffset => TimeZoneOffset.parse(value) catch return error.InvalidValue,
 
-            else => @compileError("Unsupported attribute type: " ++ @typeName(T)),
+            inline else => |EnumT| switch (@typeInfo(EnumT)) {
+                .@"enum" => std.meta.stringToEnum(EnumT, value) orelse return error.InvalidValue,
+                else => @compileError("Unsupported attribute type: " ++ @typeName(EnumT)),
+            },
         };
     }
 
@@ -2107,6 +2149,107 @@ pub const SemanticAnalyzer = struct {
         for (sema.pending_refs.items) |ref_use| {
             if (!id_map.contains(ref_use.ref.text)) {
                 try sema.emit_diagnostic(.{ .unknown_id = .{ .ref = ref_use.ref.text } }, ref_use.location);
+            }
+        }
+    }
+
+    fn resolve_references(
+        sema: *SemanticAnalyzer,
+        id_map: *const std.StringArrayHashMapUnmanaged(usize),
+    ) error{OutOfMemory}!void {
+        for (sema.blocks.items) |*block| {
+            try sema.resolve_block_references(block, id_map);
+        }
+
+        if (sema.title_block) |*title_block| {
+            try sema.resolve_span_slice(&title_block.content, id_map);
+        }
+    }
+
+    fn resolve_block_references(
+        sema: *SemanticAnalyzer,
+        block: *Block,
+        id_map: *const std.StringArrayHashMapUnmanaged(usize),
+    ) error{OutOfMemory}!void {
+        switch (block.*) {
+            .heading => |*heading| {
+                try sema.resolve_span_slice(&heading.content, id_map);
+            },
+            .paragraph => |*paragraph| {
+                try sema.resolve_span_slice(&paragraph.content, id_map);
+            },
+            .list => |*list| {
+                for (list.items) |*item| {
+                    for (item.content) |*child| {
+                        try sema.resolve_block_references(child, id_map);
+                    }
+                }
+            },
+            .image => |*image| {
+                try sema.resolve_span_slice(&image.content, id_map);
+            },
+            .preformatted => |*preformatted| {
+                try sema.resolve_span_slice(&preformatted.content, id_map);
+            },
+            .toc => {},
+            .table => |*table| {
+                for (table.rows) |*row| switch (row.*) {
+                    .columns => |*columns| {
+                        for (columns.cells) |*cell| {
+                            for (cell.content) |*child| {
+                                try sema.resolve_block_references(child, id_map);
+                            }
+                        }
+                    },
+                    .group => |*group| {
+                        try sema.resolve_span_slice(&group.content, id_map);
+                    },
+                    .row => |*table_row| {
+                        for (table_row.cells) |*cell| {
+                            for (cell.content) |*child| {
+                                try sema.resolve_block_references(child, id_map);
+                            }
+                        }
+                    },
+                };
+            },
+        }
+    }
+
+    fn resolve_span_slice(
+        sema: *SemanticAnalyzer,
+        spans: *[]Span,
+        id_map: *const std.StringArrayHashMapUnmanaged(usize),
+    ) error{OutOfMemory}!void {
+        for (spans.*) |*span| {
+            var target_index: ?usize = null;
+            switch (span.attribs.link) {
+                .ref => |ref_target| {
+                    target_index = ref_target.block_index orelse id_map.get(ref_target.ref.text);
+                    span.attribs.link = .{ .ref = .{
+                        .ref = ref_target.ref,
+                        .block_index = target_index,
+                    } };
+                },
+                else => {},
+            }
+
+            switch (span.content) {
+                .reference => |ref_content| {
+                    const resolved_index = target_index orelse id_map.get(ref_content.ref.text) orelse continue;
+                    const target_block = sema.blocks.items[resolved_index];
+                    switch (target_block) {
+                        .heading => {},
+                        else => try sema.emit_diagnostic(.empty_ref_body_target, span.location),
+                    }
+                    span.content = .{ .reference = .{
+                        .ref = ref_content.ref,
+                        .fmt = ref_content.fmt,
+                        .target_block = resolved_index,
+                    } };
+                    span.attribs.link = .{ .ref = .{ .ref = ref_content.ref, .block_index = resolved_index } };
+                },
+                else => {},
             }
         }
     }
@@ -3021,6 +3164,7 @@ pub const Parser = struct {
         @"\\sub",
         @"\\sup",
         @"\\link",
+        @"\\ref",
         @"\\date",
         @"\\time",
         @"\\datetime",
@@ -3036,6 +3180,7 @@ pub const Parser = struct {
                 .@"\\sub",
                 .@"\\sup",
                 .@"\\link",
+                .@"\\ref",
                 .@"\\date",
                 .@"\\time",
                 .@"\\datetime",
@@ -3097,6 +3242,7 @@ pub const Parser = struct {
                 .@"\\sub",
                 .@"\\sup",
                 .@"\\link",
+                .@"\\ref",
                 .@"\\date",
                 .@"\\time",
                 .@"\\datetime",
@@ -3193,7 +3339,6 @@ pub const Diagnostic = struct {
         block_list_required: NodeBodyError,
         invalid_inline_combination: InlineCombinationError,
         link_not_nestable,
-        invalid_link,
         invalid_date_time,
         invalid_date_time_body,
         invalid_date_time_fmt: DateTimeFormatError,
@@ -3210,6 +3355,7 @@ pub const Diagnostic = struct {
         column_count_mismatch: TableShapeError,
         duplicate_id: ReferenceError,
         unknown_id: ReferenceError,
+        empty_ref_body_target,
 
         // warnings:
         document_starts_with_bom,
@@ -3247,7 +3393,6 @@ pub const Diagnostic = struct {
                 .block_list_required,
                 .invalid_inline_combination,
                 .link_not_nestable,
-                .invalid_link,
                 .invalid_date_time,
                 .invalid_date_time_fmt,
                 .missing_timezone,
@@ -3264,6 +3409,7 @@ pub const Diagnostic = struct {
                 .column_count_mismatch,
                 .duplicate_id,
                 .unknown_id,
+                .empty_ref_body_target,
                 => .@"error",
 
                 .missing_document_language,
@@ -3323,7 +3469,6 @@ pub const Diagnostic = struct {
                 .redundant_inline => |ctx| try w.print("The inline \\{t} has no effect.", .{ctx.attribute}),
                 .invalid_inline_combination => |ctx| try w.print("Cannot combine \\{t} with \\{t}.", .{ ctx.first, ctx.second }),
                 .link_not_nestable => try w.writeAll("Links are not nestable"),
-                .invalid_link => try w.writeAll("\\link requires either ref=\"…\" or uri=\"…\" attribute."),
 
                 .attribute_leading_trailing_whitespace => try w.writeAll("Attribute value has invalid leading or trailing whitespace."),
 
@@ -3356,6 +3501,7 @@ pub const Diagnostic = struct {
 
                 .duplicate_id => |ctx| try w.print("The id \"{s}\" is already taken by another node.", .{ctx.ref}),
                 .unknown_id => |ctx| try w.print("The referenced id \"{s}\" does not exist.", .{ctx.ref}),
+                .empty_ref_body_target => try w.writeAll("Empty-body \\ref is only supported for headings."),
 
                 .missing_document_language => try w.writeAll("Document language is missing; set lang on the hdoc header."),
                 .tab_character => try w.writeAll("Tab character is not allowed; use spaces instead."),

--- a/src/render/dump.zig
+++ b/src/render/dump.zig
@@ -135,7 +135,11 @@ fn writeSpanAttributes(writer: *Writer, span: hdoc.Span) Writer.Error!void {
         .none => {},
         .ref => |value| {
             try writeAttrSeparator(writer, &first);
-            try writer.print("link=\"ref:{f}\"", .{std.zig.fmtString(value.text)});
+            if (value.block_index) |idx| {
+                try writer.print("link=\"ref:{f}#{d}\"", .{ std.zig.fmtString(value.ref.text), idx });
+            } else {
+                try writer.print("link=\"ref:{f}\"", .{std.zig.fmtString(value.ref.text)});
+            }
         },
         .uri => |value| {
             try writeAttrSeparator(writer, &first);
@@ -215,6 +219,17 @@ fn writeSpanContentInline(writer: *Writer, content: hdoc.Span.Content) Writer.Er
         .datetime => |datetime| {
             try writer.writeByte('"');
             try writeFormattedDateTimeInline(writer, datetime);
+            try writer.writeByte('"');
+        },
+        .reference => |reference| {
+            try writer.writeByte('"');
+            try writer.writeAll("ref:");
+            try writer.writeAll(reference.ref.text);
+            try writer.writeByte('@');
+            try writer.writeAll(@tagName(reference.fmt));
+            if (reference.target_block) |idx| {
+                try writer.print("#{d}", .{idx});
+            }
             try writer.writeByte('"');
         },
     }

--- a/src/render/html5.zig
+++ b/src/render/html5.zig
@@ -472,8 +472,13 @@ const RenderContext = struct {
             const href_value = switch (span.attribs.link) {
                 .none => unreachable,
                 .ref => |reference| blk: {
+                    if (ctx.resolveBlockId(reference.block_index)) |resolved| {
+                        var href_buffer: [128]u8 = undefined;
+                        break :blk std.fmt.bufPrint(&href_buffer, "#{s}", .{resolved}) catch unreachable;
+                    }
+
                     var href_buffer: [128]u8 = undefined;
-                    break :blk std.fmt.bufPrint(&href_buffer, "#{s}", .{reference.text}) catch unreachable;
+                    break :blk std.fmt.bufPrint(&href_buffer, "#{s}", .{reference.ref.text}) catch unreachable;
                 },
                 .uri => |uri| uri.text,
             };
@@ -530,11 +535,74 @@ const RenderContext = struct {
             .date => |date| try ctx.renderDateTimeValue(.date, date, content_lang),
             .time => |time| try ctx.renderDateTimeValue(.time, time, content_lang),
             .datetime => |datetime| try ctx.renderDateTimeValue(.datetime, datetime, content_lang),
+            .reference => |reference| {
+                try ctx.renderReference(reference, content_lang);
+            },
         }
 
         while (opened_len > 0) {
             opened_len -= 1;
             try writeEndTag(ctx.writer, opened[opened_len]);
+        }
+    }
+
+    fn renderReference(ctx: *RenderContext, reference: hdoc.Span.InlineReference, content_lang: ?[]const u8) RenderError!void {
+        if (reference.target_block) |target_idx| {
+            if (target_idx < ctx.doc.contents.len) {
+                switch (ctx.doc.contents[target_idx]) {
+                    .heading => |heading| return ctx.renderHeadingReference(reference, heading, content_lang),
+                    else => {},
+                }
+            }
+        }
+
+        try ctx.renderReferenceText(reference.ref.text, content_lang);
+    }
+
+    fn renderHeadingReference(ctx: *RenderContext, reference: hdoc.Span.InlineReference, heading: hdoc.Block.Heading, content_lang: ?[]const u8) RenderError!void {
+        var has_bdi = false;
+        if (content_lang) |lang| {
+            try writeStartTag(ctx.writer, "bdi", .regular, .{ .lang = lang });
+            has_bdi = true;
+        }
+
+        const print_index = reference.fmt != .name;
+        if (print_index) {
+            var index_buffer: [32]u8 = undefined;
+            const index_label = try formatHeadingIndexLabel(heading.index, &index_buffer);
+            try writeEscapedHtml(ctx.writer, index_label);
+        }
+
+        if (reference.fmt == .full and heading.content.len > 0) {
+            try ctx.writer.writeByte(' ');
+        }
+
+        switch (reference.fmt) {
+            .full, .name => try ctx.renderReferenceTargetSpans(heading.content),
+            .index => {},
+        }
+
+        if (has_bdi) {
+            try writeEndTag(ctx.writer, "bdi");
+        }
+    }
+
+    fn renderReferenceText(ctx: *RenderContext, text: []const u8, content_lang: ?[]const u8) RenderError!void {
+        if (content_lang) |lang| {
+            try writeStartTag(ctx.writer, "bdi", .regular, .{ .lang = lang });
+            try writeEscapedHtml(ctx.writer, text);
+            try writeEndTag(ctx.writer, "bdi");
+            return;
+        }
+
+        try writeEscapedHtml(ctx.writer, text);
+    }
+
+    fn renderReferenceTargetSpans(ctx: *RenderContext, spans: []const hdoc.Span) RenderError!void {
+        for (spans) |span| {
+            var adjusted = span;
+            adjusted.attribs.link = .none;
+            try ctx.renderSpan(adjusted);
         }
     }
 
@@ -788,6 +856,25 @@ fn formatIsoDateTime(value: hdoc.DateTime, buffer: []u8) RenderError![]const u8 
     const time_text = try formatIsoTime(value.time, &time_buffer);
 
     return std.fmt.bufPrint(buffer, "{s}T{s}", .{ date_text, time_text }) catch unreachable;
+}
+
+fn formatHeadingIndexLabel(index: hdoc.Block.Heading.Index, buffer: []u8) RenderError![]const u8 {
+    var stream = std.io.fixedBufferStream(buffer);
+    const writer = stream.writer();
+
+    const parts = switch (index) {
+        .h1 => index.h1[0..1],
+        .h2 => index.h2[0..2],
+        .h3 => index.h3[0..3],
+    };
+
+    for (parts, 0..) |value, idx| {
+        if (idx != 0) try writer.writeByte('.');
+        try writer.print("{d}", .{value});
+    }
+    try writer.writeByte('.');
+
+    return stream.getWritten();
 }
 
 fn formatDateValue(value: hdoc.FormattedDateTime(hdoc.Date), buffer: []u8) RenderError![]const u8 {

--- a/src/testsuite.zig
+++ b/src/testsuite.zig
@@ -415,6 +415,62 @@ test "parser handles unknown node types" {
     }
 }
 
+test "\\ref synthesizes heading text for empty bodies" {
+    var diagnostics: hdoc.Diagnostics = .init(std.testing.allocator);
+    defer diagnostics.deinit();
+
+    const source =
+        \\hdoc(version="2.0",lang="en");
+        \\h1(id="intro"){Introduction}
+        \\p{See \ref(ref="intro"); and \ref(ref="intro",fmt="name"); and \ref(ref="intro",fmt="index");}
+    ;
+
+    var doc = try hdoc.parse(std.testing.allocator, source, &diagnostics);
+    defer doc.deinit();
+
+    try std.testing.expect(!diagnostics.has_error());
+    try std.testing.expectEqual(@as(usize, 2), doc.contents.len);
+
+    const paragraph = doc.contents[1].paragraph;
+    const expected_formats = [_]hdoc.Span.ReferenceFormat{ .full, .name, .index };
+
+    var seen: usize = 0;
+    for (paragraph.content) |span| {
+        if (span.content != .reference) continue;
+
+        const reference = span.content.reference;
+        try std.testing.expect(seen < expected_formats.len);
+        try std.testing.expectEqual(expected_formats[seen], reference.fmt);
+        try std.testing.expectEqual(@as(?usize, 0), reference.target_block);
+
+        switch (span.attribs.link) {
+            .ref => |link| try std.testing.expectEqual(@as(?usize, 0), link.block_index),
+            else => return error.TestExpectedEqual,
+        }
+
+        seen += 1;
+    }
+
+    try std.testing.expectEqual(expected_formats.len, seen);
+}
+
+test "\\ref empty body rejects non-heading targets" {
+    var diagnostics: hdoc.Diagnostics = .init(std.testing.allocator);
+    defer diagnostics.deinit();
+
+    const source =
+        \\hdoc(version="2.0",lang="en");
+        \\p(id="p1"){Body}
+        \\p{\ref(ref="p1");}
+    ;
+
+    var doc = try hdoc.parse(std.testing.allocator, source, &diagnostics);
+    defer doc.deinit();
+
+    try std.testing.expect(diagnostics.has_error());
+    try std.testing.expect(diagnosticCodesEqual(diagnostics.items.items[0].code, .empty_ref_body_target));
+}
+
 test "table of contents inserts automatic headings when skipping levels" {
     const source =
         \\hdoc(version="2.0");
@@ -791,7 +847,7 @@ test "diagnostics for missing timezone and unknown id" {
 
     const source =
         \\hdoc(version="2.0");
-        \\p{ \time"12:00:00" \link(ref="missing"){missing} }
+        \\p{ \time"12:00:00" \ref(ref="missing"){missing} }
     ;
 
     var doc = try hdoc.parse(std.testing.allocator, source, &diagnostics);

--- a/test/html5/nesting_and_inlines.hdoc
+++ b/test/html5/nesting_and_inlines.hdoc
@@ -6,7 +6,11 @@ p "This document exercises inline formatting and nested lists."
 
 p { We can mix \em{emphasis}, \strike{strike}, \mono{monospace} text. Superscript x\sup{2} and subscript x\sub{2} also appear. }
 
-p { Links point to \link(ref="top"){local anchors} or \link(uri="https://example.com"){external sites}. }
+p { Links point to \ref(ref="top"){local anchors} or \link(uri="https://example.com"){external sites}. }
+
+h2(id="formatted") {Formatted \em{Heading}}
+
+p { Empty-body references become \ref(ref="formatted",fmt="full"); \ref(ref="formatted",fmt="name"); and \ref(ref="formatted",fmt="index"); }
 
 ul {
   li { p "Top-level item one" }

--- a/test/html5/nesting_and_inlines.html
+++ b/test/html5/nesting_and_inlines.html
@@ -5,6 +5,8 @@
 <p>This document exercises inline formatting and nested lists.</p>
 <p>We can mix <em>emphasis</em>, <s>strike</s>, <code class="hdoc-code">monospace</code> text. Superscript x<sup>2</sup> and subscript x<sub>2</sub> also appear.</p>
 <p>Links point to <a href="#top">local anchors</a> or <a href="https://example.com">external sites</a>.</p>
+<h3 id="formatted">§1.1 Formatted <em>Heading</em></h3>
+<p>Empty-body references become <a href="#formatted">1.1. Formatted <em>Heading</em></a> <a href="#formatted">Formatted <em>Heading</em></a> and <a href="#formatted">1.1.</a></p>
 <ul>
   <li>
     <p>Top-level item one</p>


### PR DESCRIPTION
## Summary
- render empty-body references using resolved heading spans and preserve heading formatting in HTML output
- keep plaintext reference rendering simple in the semantic layer by rejecting unexpected references
- document a normative rule that \ref cannot appear inside h1, h2, h3, or title elements and clarify the placement in the \ref element section

## Testing
- zig build
- zig build test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695850f172248322a09da13f894d8cd9)