### PR TITLE
Add footnote handling and rendering

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -7,6 +7,7 @@ const snapshot_files: []const []const u8 = &.{
     "test/snapshot/nesting_and_inlines.hdoc",
     "test/snapshot/paragraph_styles.hdoc",
     "test/snapshot/tables.hdoc",
+    "test/snapshot/footnotes.hdoc",
 };
 
 pub fn build(b: *std.Build) void {

--- a/src/hyperdoc.zig
+++ b/src/hyperdoc.zig
@@ -42,6 +42,11 @@ pub const Document = struct {
     }
 };
 
+pub const FootnoteKind = enum {
+    footnote,
+    citation,
+};
+
 /// A top level layouting element of a document.
 /// Each block is a rectangular element on the screen with
 /// variable height, but a fixed width.
@@ -56,6 +61,7 @@ pub const Block = union(enum) {
     preformatted: Preformatted,
     toc: TableOfContents,
     table: Table,
+    footnotes: Footnotes,
 
     pub const Heading = struct {
         index: Index,
@@ -162,6 +168,18 @@ pub const Block = union(enum) {
         lang: LanguageTag,
         content: []Span,
     };
+
+    pub const Footnotes = struct {
+        lang: LanguageTag,
+        entries: []FootnoteEntry,
+    };
+
+    pub const FootnoteEntry = struct {
+        index: usize,
+        kind: FootnoteKind,
+        lang: LanguageTag,
+        content: []Span,
+    };
 };
 
 pub fn FormattedDateTime(comptime DT: type) type {
@@ -180,6 +198,7 @@ pub const Span = struct {
         time: FormattedDateTime(Time),
         datetime: FormattedDateTime(DateTime),
         reference: InlineReference,
+        footnote: Footnote,
     };
 
     pub const InlineReference = struct {
@@ -225,6 +244,11 @@ pub const Span = struct {
     content: Content,
     attribs: Attributes,
     location: Parser.Location,
+};
+
+pub const Footnote = struct {
+    kind: FootnoteKind,
+    index: usize,
 };
 
 pub const ScriptPosition = enum {
@@ -618,6 +642,12 @@ pub fn parse(
     const block_locations = try sema.block_locations.toOwnedSlice(arena.allocator());
     const toc = try sema.build_toc(contents, block_locations);
 
+    if (sema.has_pending_footnotes()) {
+        if (sema.first_footnote_location) |location| {
+            try sema.emit_diagnostic(.footnote_missing_dump, location);
+        }
+    }
+
     return .{
         .arena = arena,
         .contents = contents,
@@ -753,6 +783,13 @@ pub const SemanticAnalyzer = struct {
         }
     };
 
+    const FootnoteDefinition = struct {
+        kind: FootnoteKind,
+        index: usize,
+        lang: LanguageTag,
+        content: []Span,
+    };
+
     arena: std.mem.Allocator,
     diagnostics: ?*Diagnostics,
     code: []const u8,
@@ -766,6 +803,10 @@ pub const SemanticAnalyzer = struct {
     ids: std.ArrayList(?Reference) = .empty,
     id_locations: std.ArrayList(?Parser.Location) = .empty,
     pending_refs: std.ArrayList(RefUse) = .empty,
+    footnote_counters: std.EnumArray(FootnoteKind, usize) = std.EnumArray(FootnoteKind, usize).initFill(0),
+    footnote_pending: std.EnumArray(FootnoteKind, std.ArrayList(Block.FootnoteEntry)) = std.EnumArray(FootnoteKind, std.ArrayList(Block.FootnoteEntry)).initFill(.empty),
+    footnote_keys: std.StringArrayHashMapUnmanaged(FootnoteDefinition) = .empty,
+    first_footnote_location: ?Parser.Location = null,
 
     current_heading_level: usize = 0,
     heading_counters: [Block.Heading.Level.count]u16 = @splat(0),
@@ -933,6 +974,10 @@ pub const SemanticAnalyzer = struct {
                 const toc, const id = try sema.translate_toc_node(node);
                 return .{ .{ .toc = toc }, id };
             },
+            .footnotes => {
+                const footnotes = try sema.translate_footnotes_node(node);
+                return .{ .{ .footnotes = footnotes }, null };
+            },
             .table => {
                 const table, const id = try sema.translate_table_node(node);
                 return .{ .{ .table = table }, id };
@@ -953,6 +998,7 @@ pub const SemanticAnalyzer = struct {
             .@"\\time",
             .@"\\date",
             .@"\\datetime",
+            .@"\\footnote",
             .text,
             .columns,
             .group,
@@ -1170,6 +1216,51 @@ pub const SemanticAnalyzer = struct {
         };
 
         return .{ toc, attrs.id };
+    }
+
+    fn translate_footnotes_node(sema: *SemanticAnalyzer, node: Parser.Node) !Block.Footnotes {
+        const attrs = try sema.get_attributes(node, struct {
+            lang: LanguageTag = .inherit,
+            kind: ?FootnoteKind = null,
+        });
+
+        switch (node.body) {
+            .empty => {},
+            .list => |child_nodes| {
+                for (child_nodes) |child_node| {
+                    try sema.emit_diagnostic(.illegal_child_item, child_node.location);
+                }
+            },
+            .string, .verbatim, .text_span => {
+                try sema.emit_diagnostic(.illegal_child_item, node.location);
+            },
+        }
+
+        var entries: std.ArrayList(Block.FootnoteEntry) = .empty;
+        defer entries.deinit(sema.arena);
+
+        const kinds: []const FootnoteKind = if (attrs.kind) |kind|
+            &[_]FootnoteKind{kind}
+        else
+            &[_]FootnoteKind{ .footnote, .citation };
+
+        for (kinds) |kind| {
+            const pending = sema.footnote_pending.getPtr(kind);
+            if (pending.items.len == 0)
+                continue;
+
+            try entries.appendSlice(sema.arena, pending.items);
+            pending.clearRetainingCapacity();
+        }
+
+        if (!sema.has_pending_footnotes()) {
+            sema.first_footnote_location = null;
+        }
+
+        return .{
+            .lang = attrs.lang,
+            .entries = try entries.toOwnedSlice(sema.arena),
+        };
     }
 
     fn translate_table_node(sema: *SemanticAnalyzer, node: Parser.Node) !struct { Block.Table, ?Reference } {
@@ -1497,7 +1588,7 @@ pub const SemanticAnalyzer = struct {
 
                     try merger.output.append(merger.arena, span);
                 },
-                .reference => {
+                .reference, .footnote => {
                     try merger.flush_internal(.keep);
                     std.debug.assert(merger.current_span.items.len == 0);
 
@@ -1782,6 +1873,85 @@ pub const SemanticAnalyzer = struct {
                     .location = node.location,
                 });
             },
+            .@"\\footnote" => {
+                const props = try sema.get_attributes(node, struct {
+                    key: ?Reference = null,
+                    ref: ?Reference = null,
+                    kind: ?FootnoteKind = null,
+                    lang: LanguageTag = .inherit,
+                });
+
+                const has_body = node.body != .empty;
+                if (props.key != null and props.ref != null) {
+                    try sema.emit_diagnostic(.footnote_conflicting_key_ref, node.location);
+                    return;
+                }
+
+                if (has_body) {
+                    if (props.ref != null) {
+                        try sema.emit_diagnostic(.footnote_conflicting_key_ref, node.location);
+                        return;
+                    }
+                } else {
+                    if (props.ref == null) {
+                        try sema.emit_diagnostic(.footnote_missing_ref, node.location);
+                        return;
+                    }
+                    if (props.kind != null) {
+                        try sema.emit_diagnostic(.footnote_kind_on_reference, get_attribute_location(node, "kind", .name) orelse node.location);
+                    }
+
+                    const definition = sema.footnote_keys.get(props.ref.?.text) orelse {
+                        try sema.emit_diagnostic(.{ .unknown_footnote_key = .{ .ref = props.ref.?.text } }, get_attribute_location(node, "ref", .value) orelse node.location);
+                        return;
+                    };
+
+                    try sema.enqueue_footnote(definition);
+                    sema.note_footnote_marker(node.location);
+                    try spans.append(sema.arena, .{
+                        .content = .{ .footnote = .{
+                            .kind = definition.kind,
+                            .index = definition.index,
+                        } },
+                        .attribs = attribs,
+                        .location = node.location,
+                    });
+                    return;
+                }
+
+                if (!has_body) {
+                    try sema.emit_diagnostic(.footnote_missing_body, node.location);
+                    return;
+                }
+
+                const kind = props.kind orelse FootnoteKind.footnote;
+
+                var content_spans: std.ArrayList(Span) = .empty;
+                defer content_spans.deinit(sema.arena);
+
+                const content_attribs = try sema.derive_attribute(node.location, attribs, .{ .lang = props.lang });
+                try sema.translate_inline_body(&content_spans, node.body, content_attribs, .emit_diagnostic);
+
+                const compacted = try sema.compact_spans(content_spans.items, .one_space);
+                if (compacted.len == 0) {
+                    try sema.emit_diagnostic(.footnote_missing_body, node.location);
+                    return;
+                }
+
+                const key_location = get_attribute_location(node, "key", .value);
+                const definition = try sema.append_footnote_definition(kind, props.lang, compacted, props.key, node.location, key_location);
+                try sema.enqueue_footnote(definition);
+                sema.note_footnote_marker(node.location);
+
+                try spans.append(sema.arena, .{
+                    .content = .{ .footnote = .{
+                        .kind = definition.kind,
+                        .index = definition.index,
+                    } },
+                    .attribs = attribs,
+                    .location = node.location,
+                });
+            },
 
             .hdoc,
             .h1,
@@ -1800,6 +1970,7 @@ pub const SemanticAnalyzer = struct {
             .img,
             .pre,
             .toc,
+            .footnotes,
             .table,
             .columns,
             .group,
@@ -1913,6 +2084,7 @@ pub const SemanticAnalyzer = struct {
                         try output.appendSlice(sema.arena, text);
                     },
                 },
+                .footnote => {},
             }
         }
 
@@ -2199,6 +2371,7 @@ pub const SemanticAnalyzer = struct {
             DateTime => DateTime.parse(value, timezone_hint) catch return error.InvalidValue,
             LanguageTag => LanguageTag.parse(value) catch return error.InvalidValue,
             TimeZoneOffset => TimeZoneOffset.parse(value) catch return error.InvalidValue,
+            FootnoteKind => std.meta.stringToEnum(FootnoteKind, value) orelse return error.InvalidValue,
 
             inline else => |EnumT| switch (@typeInfo(EnumT)) {
                 .@"enum" => std.meta.stringToEnum(EnumT, value) orelse return error.InvalidValue,
@@ -2258,6 +2431,12 @@ pub const SemanticAnalyzer = struct {
                     try sema.resolve_block_references(child, id_map);
                 }
             },
+            .footnotes => |*footnotes| {
+                for (footnotes.entries) |*entry| {
+                    try sema.resolve_span_slice(&entry.content, id_map);
+                }
+            },
+
             .toc => {},
             .table => |*table| {
                 for (table.rows) |*row| switch (row.*) {
@@ -2415,6 +2594,68 @@ pub const SemanticAnalyzer = struct {
             .h2 => .h3,
             .h3 => .h3,
         };
+    }
+
+    fn enqueue_footnote(sema: *SemanticAnalyzer, definition: FootnoteDefinition) !void {
+        const pending = sema.footnote_pending.getPtr(definition.kind);
+        for (pending.items) |entry| {
+            if (entry.index == definition.index) {
+                return;
+            }
+        }
+
+        try pending.append(sema.arena, .{
+            .index = definition.index,
+            .kind = definition.kind,
+            .lang = definition.lang,
+            .content = definition.content,
+        });
+    }
+
+    fn append_footnote_definition(
+        sema: *SemanticAnalyzer,
+        kind: FootnoteKind,
+        lang: LanguageTag,
+        content: []Span,
+        key: ?Reference,
+        node_location: Parser.Location,
+        key_location: ?Parser.Location,
+    ) !FootnoteDefinition {
+        const counter = sema.footnote_counters.getPtr(kind);
+        counter.* += 1;
+        const definition: FootnoteDefinition = .{
+            .kind = kind,
+            .index = counter.*,
+            .lang = lang,
+            .content = content,
+        };
+
+        if (key) |reference| {
+            const gop = try sema.footnote_keys.getOrPut(sema.arena, reference.text);
+            if (gop.found_existing) {
+                try sema.emit_diagnostic(.{ .duplicate_footnote_key = .{ .ref = reference.text } }, key_location orelse node_location);
+            } else {
+                gop.value_ptr.* = definition;
+            }
+        }
+
+        return definition;
+    }
+
+    fn note_footnote_marker(sema: *SemanticAnalyzer, location: Parser.Location) void {
+        if (sema.first_footnote_location == null) {
+            sema.first_footnote_location = location;
+        }
+    }
+
+    fn has_pending_footnotes(sema: *SemanticAnalyzer) bool {
+        for (std.meta.tags(FootnoteKind)) |kind| {
+            if (sema.footnote_pending.get(kind).items.len > 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// Computes the next index number for a heading of the given level:
@@ -3217,6 +3458,7 @@ pub const Parser = struct {
         img,
         pre,
         toc,
+        footnotes,
         table,
         columns,
         group,
@@ -3235,6 +3477,7 @@ pub const Parser = struct {
         @"\\date",
         @"\\time",
         @"\\datetime",
+        @"\\footnote",
 
         unknown_block,
         unknown_inline,
@@ -3251,6 +3494,7 @@ pub const Parser = struct {
                 .@"\\date",
                 .@"\\time",
                 .@"\\datetime",
+                .@"\\footnote",
                 .unknown_inline,
                 .text,
                 => true,
@@ -3272,6 +3516,7 @@ pub const Parser = struct {
                 .img,
                 .pre,
                 .toc,
+                .footnotes,
                 .table,
                 .columns,
                 .group,
@@ -3295,6 +3540,7 @@ pub const Parser = struct {
                 .img,
                 .pre,
                 .toc,
+                .footnotes,
                 .group,
 
                 .@"\\em",
@@ -3307,6 +3553,7 @@ pub const Parser = struct {
                 .@"\\date",
                 .@"\\time",
                 .@"\\datetime",
+                .@"\\footnote",
 
                 .unknown_inline,
                 .unknown_block, // Unknown blocks must also have inline bodies to optimally retain body contents
@@ -3426,6 +3673,12 @@ pub const Diagnostic = struct {
         duplicate_id: ReferenceError,
         unknown_id: ReferenceError,
         empty_ref_body_target,
+        duplicate_footnote_key: ReferenceError,
+        unknown_footnote_key: ReferenceError,
+        footnote_conflicting_key_ref,
+        footnote_missing_ref,
+        footnote_missing_body,
+        footnote_kind_on_reference,
 
         // warnings:
         document_starts_with_bom,
@@ -3442,6 +3695,7 @@ pub const Diagnostic = struct {
         tab_character,
         automatic_heading_insertion: AutomaticHeading,
         title_inline_date_time_without_header,
+        footnote_missing_dump,
 
         pub fn severity(code: Code) Severity {
             return switch (code) {
@@ -3483,6 +3737,12 @@ pub const Diagnostic = struct {
                 .duplicate_id,
                 .unknown_id,
                 .empty_ref_body_target,
+                .duplicate_footnote_key,
+                .unknown_footnote_key,
+                .footnote_conflicting_key_ref,
+                .footnote_missing_ref,
+                .footnote_missing_body,
+                .footnote_kind_on_reference,
                 => .@"error",
 
                 .missing_document_language,
@@ -3499,6 +3759,7 @@ pub const Diagnostic = struct {
                 .document_starts_with_bom,
                 .automatic_heading_insertion,
                 .title_inline_date_time_without_header,
+                .footnote_missing_dump,
                 => .warning,
             };
         }
@@ -3578,12 +3839,19 @@ pub const Diagnostic = struct {
                 .duplicate_id => |ctx| try w.print("The id \"{s}\" is already taken by another node.", .{ctx.ref}),
                 .unknown_id => |ctx| try w.print("The referenced id \"{s}\" does not exist.", .{ctx.ref}),
                 .empty_ref_body_target => try w.writeAll("Empty-body \\ref is only supported for headings."),
+                .duplicate_footnote_key => |ctx| try w.print("The footnote key \"{s}\" is already defined.", .{ctx.ref}),
+                .unknown_footnote_key => |ctx| try w.print("The referenced footnote key \"{s}\" does not exist.", .{ctx.ref}),
+                .footnote_conflicting_key_ref => try w.writeAll("\\footnote attributes 'key' and 'ref' cannot be used together."),
+                .footnote_missing_ref => try w.writeAll("\\footnote without a body requires a ref=\"...\" attribute."),
+                .footnote_missing_body => try w.writeAll("\\footnote definitions require a non-empty body."),
+                .footnote_kind_on_reference => try w.writeAll("Attribute 'kind' is only valid on defining \\footnote entries."),
 
                 .missing_document_language => try w.writeAll("Document language is missing; set lang on the hdoc header."),
                 .tab_character => try w.writeAll("Tab character is not allowed; use spaces instead."),
 
                 .automatic_heading_insertion => |ctx| try w.print("Inserted automatic {t} to fill heading level gap.", .{ctx.level}),
                 .title_inline_date_time_without_header => try w.writeAll("Title block contains \\date/\\time/\\datetime but hdoc(title=\"...\") is missing; metadata title cannot be derived reliably."),
+                .footnote_missing_dump => try w.writeAll("Document contains footnotes but no footnotes(...) block to render them."),
             }
         }
     };

--- a/src/hyperdoc.zig
+++ b/src/hyperdoc.zig
@@ -643,7 +643,7 @@ pub fn parse(
     const toc = try sema.build_toc(contents, block_locations);
 
     if (sema.has_pending_footnotes()) {
-        if (sema.first_footnote_location) |location| {
+        if (sema.first_pending_footnote_location()) |location| {
             try sema.emit_diagnostic(.footnote_missing_dump, location);
         }
     }
@@ -806,7 +806,7 @@ pub const SemanticAnalyzer = struct {
     footnote_counters: std.EnumArray(FootnoteKind, usize) = std.EnumArray(FootnoteKind, usize).initFill(0),
     footnote_pending: std.EnumArray(FootnoteKind, std.ArrayList(Block.FootnoteEntry)) = std.EnumArray(FootnoteKind, std.ArrayList(Block.FootnoteEntry)).initFill(.empty),
     footnote_keys: std.StringArrayHashMapUnmanaged(FootnoteDefinition) = .empty,
-    first_footnote_location: ?Parser.Location = null,
+    first_footnote_locations: std.EnumArray(FootnoteKind, ?Parser.Location) = std.EnumArray(FootnoteKind, ?Parser.Location).initFill(null),
 
     current_heading_level: usize = 0,
     heading_counters: [Block.Heading.Level.count]u16 = @splat(0),
@@ -1251,10 +1251,13 @@ pub const SemanticAnalyzer = struct {
 
             try entries.appendSlice(sema.arena, pending.items);
             pending.clearRetainingCapacity();
+            sema.first_footnote_locations.getPtr(kind).* = null;
         }
 
         if (!sema.has_pending_footnotes()) {
-            sema.first_footnote_location = null;
+            for (std.meta.tags(FootnoteKind)) |kind| {
+                sema.first_footnote_locations.getPtr(kind).* = null;
+            }
         }
 
         return .{
@@ -1907,7 +1910,7 @@ pub const SemanticAnalyzer = struct {
                     };
 
                     try sema.enqueue_footnote(definition);
-                    sema.note_footnote_marker(node.location);
+                    sema.note_footnote_marker(definition.kind, node.location);
                     try spans.append(sema.arena, .{
                         .content = .{ .footnote = .{
                             .kind = definition.kind,
@@ -1941,7 +1944,7 @@ pub const SemanticAnalyzer = struct {
                 const key_location = get_attribute_location(node, "key", .value);
                 const definition = try sema.append_footnote_definition(kind, props.lang, compacted, props.key, node.location, key_location);
                 try sema.enqueue_footnote(definition);
-                sema.note_footnote_marker(node.location);
+                sema.note_footnote_marker(definition.kind, node.location);
 
                 try spans.append(sema.arena, .{
                     .content = .{ .footnote = .{
@@ -2642,9 +2645,10 @@ pub const SemanticAnalyzer = struct {
         return definition;
     }
 
-    fn note_footnote_marker(sema: *SemanticAnalyzer, location: Parser.Location) void {
-        if (sema.first_footnote_location == null) {
-            sema.first_footnote_location = location;
+    fn note_footnote_marker(sema: *SemanticAnalyzer, kind: FootnoteKind, location: Parser.Location) void {
+        const slot = sema.first_footnote_locations.getPtr(kind);
+        if (slot.* == null) {
+            slot.* = location;
         }
     }
 
@@ -2656,6 +2660,23 @@ pub const SemanticAnalyzer = struct {
         }
 
         return false;
+    }
+
+    fn first_pending_footnote_location(sema: *SemanticAnalyzer) ?Parser.Location {
+        var earliest: ?Parser.Location = null;
+
+        for (std.meta.tags(FootnoteKind)) |kind| {
+            if (sema.footnote_pending.get(kind).items.len == 0)
+                continue;
+
+            if (sema.first_footnote_locations.get(kind)) |location| {
+                if (earliest == null or location.offset < earliest.?.offset) {
+                    earliest = location;
+                }
+            }
+        }
+
+        return earliest;
     }
 
     /// Computes the next index number for a heading of the given level:

--- a/src/render/dump.zig
+++ b/src/render/dump.zig
@@ -221,6 +221,9 @@ fn writeSpanContentInline(writer: *Writer, content: hdoc.Span.Content) Writer.Er
             try writeFormattedDateTimeInline(writer, datetime);
             try writer.writeByte('"');
         },
+        .footnote => |footnote| {
+            try writer.print("\"footnote:{s}:{d}\"", .{ @tagName(footnote.kind), footnote.index });
+        },
         .reference => |reference| {
             try writer.writeByte('"');
             try writer.writeAll("ref:");
@@ -318,6 +321,28 @@ fn dumpListItemsField(writer: *Writer, indent: usize, key: []const u8, items: []
         try writeIndent(writer, indent + indent_step);
         try writer.writeAll("- ");
         try dumpListItem(writer, indent + indent_step, item);
+    }
+}
+
+fn dumpFootnoteEntry(writer: *Writer, indent: usize, entry: hdoc.Block.FootnoteEntry) Writer.Error!void {
+    try writeIndent(writer, indent);
+    try writer.print("index: {}\n", .{entry.index});
+    try dumpEnumField(writer, indent, "kind", entry.kind);
+    try dumpOptionalStringField(writer, indent, "lang", entry.lang.text);
+    try dumpSpanListField(writer, indent, "content", entry.content);
+}
+
+fn dumpFootnoteEntries(writer: *Writer, indent: usize, entries: []const hdoc.Block.FootnoteEntry) Writer.Error!void {
+    try writeIndent(writer, indent);
+    if (entries.len == 0) {
+        try writer.writeAll("entries: []\n");
+        return;
+    }
+    try writer.writeAll("entries:\n");
+    for (entries) |entry| {
+        try writeIndent(writer, indent + indent_step);
+        try writer.writeAll("- ");
+        try dumpFootnoteEntry(writer, indent + indent_step, entry);
     }
 }
 
@@ -456,6 +481,11 @@ fn dumpBlockInline(writer: *Writer, indent: usize, block: hdoc.Block) Writer.Err
             try writeTypeTag(writer, "toc");
             try dumpOptionalStringField(writer, indent + indent_step, "lang", toc.lang.text);
             try dumpOptionalNumberField(writer, indent + indent_step, "depth", @as(?u8, toc.depth));
+        },
+        .footnotes => |footnotes| {
+            try writeTypeTag(writer, "footnotes");
+            try dumpOptionalStringField(writer, indent + indent_step, "lang", footnotes.lang.text);
+            try dumpFootnoteEntries(writer, indent + indent_step, footnotes.entries);
         },
         .table => |table| {
             try writeTypeTag(writer, "table");

--- a/src/render/html5.zig
+++ b/src/render/html5.zig
@@ -32,6 +32,7 @@ const RenderContext = struct {
             .preformatted => |preformatted| try ctx.renderPreformatted(preformatted, block_index, indent),
             .toc => |toc| try ctx.renderTableOfContents(toc, block_index, indent),
             .table => |table| try ctx.renderTable(table, block_index, indent),
+            .footnotes => |footnotes| try ctx.renderFootnotes(footnotes, block_index, indent),
         }
     }
 
@@ -359,6 +360,78 @@ const RenderContext = struct {
         try ctx.writer.writeByte('\n');
     }
 
+    fn renderFootnotes(ctx: *RenderContext, footnotes: hdoc.Block.Footnotes, block_index: ?usize, indent: usize) RenderError!void {
+        const lang_attr = langAttribute(footnotes.lang);
+        const id_attr = ctx.resolveBlockId(block_index);
+
+        try writeIndent(ctx.writer, indent);
+        try writeStartTag(ctx.writer, "div", .regular, .{
+            .id = id_attr,
+            .lang = lang_attr,
+            .class = "hdoc-footnotes",
+        });
+        try ctx.writer.writeByte('\n');
+
+        const kinds = [_]hdoc.FootnoteKind{ .footnote, .citation };
+        for (kinds) |kind| {
+            var first_index: ?usize = null;
+            var count: usize = 0;
+
+            for (footnotes.entries) |entry| {
+                if (entry.kind != kind)
+                    continue;
+                if (first_index == null)
+                    first_index = entry.index;
+                count += 1;
+            }
+
+            if (count == 0)
+                continue;
+
+            try writeIndent(ctx.writer, indent + indent_step);
+            var class_buffer: [64]u8 = undefined;
+            const list_class = std.fmt.bufPrint(&class_buffer, "hdoc-footnote-list hdoc-{s}", .{footnoteSlug(kind)}) catch unreachable;
+            try writeStartTag(ctx.writer, "ol", .regular, .{
+                .class = list_class,
+                .start = first_index,
+            });
+            try ctx.writer.writeByte('\n');
+
+            for (footnotes.entries) |entry| {
+                if (entry.kind != kind)
+                    continue;
+
+                var id_buffer: [64]u8 = undefined;
+                const entry_id = ctx.footnoteId(entry.kind, entry.index, &id_buffer);
+
+                try writeIndent(ctx.writer, indent + 2 * indent_step);
+                try writeStartTag(ctx.writer, "li", .regular, .{
+                    .id = entry_id,
+                    .lang = langAttribute(entry.lang),
+                });
+                if (entry.content.len > 0) {
+                    try ctx.writer.writeByte('\n');
+                    try writeIndent(ctx.writer, indent + 3 * indent_step);
+                    try writeStartTag(ctx.writer, "p", .regular, .{ .lang = langAttribute(entry.lang) });
+                    try ctx.renderSpans(entry.content);
+                    try writeEndTag(ctx.writer, "p");
+                    try ctx.writer.writeByte('\n');
+                    try writeIndent(ctx.writer, indent + 2 * indent_step);
+                }
+                try writeEndTag(ctx.writer, "li");
+                try ctx.writer.writeByte('\n');
+            }
+
+            try writeIndent(ctx.writer, indent + indent_step);
+            try writeEndTag(ctx.writer, "ol");
+            try ctx.writer.writeByte('\n');
+        }
+
+        try writeIndent(ctx.writer, indent);
+        try writeEndTag(ctx.writer, "div");
+        try ctx.writer.writeByte('\n');
+    }
+
     fn renderHeaderRow(ctx: *RenderContext, columns: hdoc.Block.TableColumns, indent: usize, has_title_column: bool) RenderError!void {
         try writeIndent(ctx.writer, indent);
         try writeStartTag(ctx.writer, "tr", .regular, .{ .lang = langAttribute(columns.lang) });
@@ -471,6 +544,18 @@ const RenderContext = struct {
         return null;
     }
 
+    fn footnoteSlug(kind: hdoc.FootnoteKind) []const u8 {
+        return switch (kind) {
+            .footnote => "footnote",
+            .citation => "citation",
+        };
+    }
+
+    fn footnoteId(ctx: *RenderContext, kind: hdoc.FootnoteKind, index: usize, buffer: []u8) []const u8 {
+        _ = ctx;
+        return std.fmt.bufPrint(buffer, "hdoc-{s}-{d}", .{ footnoteSlug(kind), index }) catch unreachable;
+    }
+
     fn renderSpans(ctx: *RenderContext, spans: []const hdoc.Span) RenderError!void {
         for (spans) |span| {
             try ctx.renderSpan(span);
@@ -553,6 +638,21 @@ const RenderContext = struct {
             .datetime => |datetime| try ctx.renderDateTimeValue(.datetime, datetime, content_lang),
             .reference => |reference| {
                 try ctx.renderReference(reference, content_lang);
+            },
+            .footnote => |footnote| {
+                var id_buffer: [64]u8 = undefined;
+                const target_id = ctx.footnoteId(footnote.kind, footnote.index, &id_buffer);
+                var href_buffer: [64]u8 = undefined;
+                const href = std.fmt.bufPrint(&href_buffer, "#{s}", .{target_id}) catch unreachable;
+
+                var class_buffer: [64]u8 = undefined;
+                const class_attr = std.fmt.bufPrint(&class_buffer, "hdoc-footnote-ref hdoc-{s}", .{footnoteSlug(footnote.kind)}) catch unreachable;
+
+                try writeStartTag(ctx.writer, "sup", .regular, .{ .class = class_attr, .lang = content_lang });
+                try writeStartTag(ctx.writer, "a", .regular, .{ .href = href });
+                try ctx.writer.print("{d}", .{footnote.index});
+                try writeEndTag(ctx.writer, "a");
+                try writeEndTag(ctx.writer, "sup");
             },
         }
 

--- a/src/testsuite.zig
+++ b/src/testsuite.zig
@@ -593,6 +593,120 @@ test "table of contents inserts automatic headings when skipping levels" {
     try std.testing.expectEqual(@as(usize, 0), trailing_h1_child.children.len);
 }
 
+test "footnotes collect entries per dump" {
+    const source =
+        \\hdoc(version="2.0",lang="en");
+        \\p{Intro \footnote{first} \footnote(kind="citation",key="cite1"){c1}}
+        \\footnotes;
+        \\p{Again \footnote(ref="cite1"); \footnote{second}}
+        \\footnotes(kind="citation");
+        \\footnotes;
+    ;
+
+    var diagnostics: hdoc.Diagnostics = .init(std.testing.allocator);
+    defer diagnostics.deinit();
+
+    var doc = try hdoc.parse(std.testing.allocator, source, &diagnostics);
+    defer doc.deinit();
+
+    try std.testing.expect(!diagnostics.has_error());
+    try std.testing.expectEqual(@as(usize, 5), doc.contents.len);
+
+    const first_dump = switch (doc.contents[1]) {
+        .footnotes => |value| value,
+        else => return error.TestExpectedEqual,
+    };
+    try std.testing.expectEqual(@as(usize, 2), first_dump.entries.len);
+    try std.testing.expectEqual(hdoc.FootnoteKind.footnote, first_dump.entries[0].kind);
+    try std.testing.expectEqual(@as(usize, 1), first_dump.entries[0].index);
+    try std.testing.expectEqual(hdoc.FootnoteKind.citation, first_dump.entries[1].kind);
+    try std.testing.expectEqual(@as(usize, 1), first_dump.entries[1].index);
+
+    const second_dump = switch (doc.contents[3]) {
+        .footnotes => |value| value,
+        else => return error.TestExpectedEqual,
+    };
+    try std.testing.expectEqual(@as(usize, 1), second_dump.entries.len);
+    try std.testing.expectEqual(hdoc.FootnoteKind.citation, second_dump.entries[0].kind);
+    try std.testing.expectEqual(@as(usize, 1), second_dump.entries[0].index);
+
+    const final_dump = switch (doc.contents[4]) {
+        .footnotes => |value| value,
+        else => return error.TestExpectedEqual,
+    };
+    try std.testing.expectEqual(@as(usize, 1), final_dump.entries.len);
+    try std.testing.expectEqual(hdoc.FootnoteKind.footnote, final_dump.entries[0].kind);
+    try std.testing.expectEqual(@as(usize, 2), final_dump.entries[0].index);
+}
+
+test "warn when footnotes are missing dumps" {
+    const source =
+        \\hdoc(version="2.0",lang="en");
+        \\p{Body \footnote{content}}
+    ;
+
+    var diagnostics: hdoc.Diagnostics = .init(std.testing.allocator);
+    defer diagnostics.deinit();
+
+    var doc = try hdoc.parse(std.testing.allocator, source, &diagnostics);
+    defer doc.deinit();
+
+    var saw_warning = false;
+    for (diagnostics.items.items) |item| {
+        if (diagnosticCodesEqual(item.code, .footnote_missing_dump)) {
+            saw_warning = true;
+            break;
+        }
+    }
+    try std.testing.expect(saw_warning);
+}
+
+test "warn when footnotes remain after intermediate dump" {
+    const source =
+        \\hdoc(version="2.0",lang="en");
+        \\p{First \footnote{one}}
+        \\footnotes{}
+        \\p{Second \footnote{two}}
+    ;
+
+    var diagnostics: hdoc.Diagnostics = .init(std.testing.allocator);
+    defer diagnostics.deinit();
+
+    var doc = try hdoc.parse(std.testing.allocator, source, &diagnostics);
+    defer doc.deinit();
+
+    var saw_warning = false;
+    for (diagnostics.items.items) |item| {
+        if (diagnosticCodesEqual(item.code, .footnote_missing_dump)) {
+            saw_warning = true;
+            break;
+        }
+    }
+    try std.testing.expect(saw_warning);
+}
+
+test "no warning when footnotes are drained after later dump" {
+    const source =
+        \\hdoc(version="2.0",lang="en");
+        \\p{First \footnote{one}}
+        \\footnotes{}
+        \\p{Second \footnote{two}}
+        \\footnotes{}
+    ;
+
+    var diagnostics: hdoc.Diagnostics = .init(std.testing.allocator);
+    defer diagnostics.deinit();
+
+    var doc = try hdoc.parse(std.testing.allocator, source, &diagnostics);
+    defer doc.deinit();
+
+    for (diagnostics.items.items) |item| {
+        if (diagnosticCodesEqual(item.code, .footnote_missing_dump)) {
+            return error.TestExpectedEqual;
+        }
+    }
+}
+
 fn diagnosticCodesEqual(lhs: hdoc.Diagnostic.Code, rhs: hdoc.Diagnostic.Code) bool {
     if (std.meta.activeTag(lhs) != std.meta.activeTag(rhs))
         return false;

--- a/src/testsuite.zig
+++ b/src/testsuite.zig
@@ -685,6 +685,33 @@ test "warn when footnotes remain after intermediate dump" {
     try std.testing.expect(saw_warning);
 }
 
+test "footnote missing dump warning points to earliest remaining kind" {
+    const source =
+        \\hdoc(version="2.0",lang="en");
+        \\p{First \footnote{one}}
+        \\p{C \footnote(kind="citation",key="cite"){two}}
+        \\footnotes(kind="footnote");
+    ;
+
+    var diagnostics: hdoc.Diagnostics = .init(std.testing.allocator);
+    defer diagnostics.deinit();
+
+    var doc = try hdoc.parse(std.testing.allocator, source, &diagnostics);
+    defer doc.deinit();
+
+    var warning: ?hdoc.Diagnostic = null;
+    for (diagnostics.items.items) |item| {
+        if (diagnosticCodesEqual(item.code, .footnote_missing_dump)) {
+            warning = item;
+            break;
+        }
+    }
+
+    try std.testing.expect(warning != null);
+    try std.testing.expectEqual(@as(u32, 3), warning.?.location.line);
+    try std.testing.expectEqual(@as(u32, 5), warning.?.location.column);
+}
+
 test "no warning when footnotes are drained after later dump" {
     const source =
         \\hdoc(version="2.0",lang="en");

--- a/test/compare.zig
+++ b/test/compare.zig
@@ -21,10 +21,23 @@ pub fn main() !u8 {
     const ground_truth_path = argv[1];
     const new_input_path = argv[2];
 
-    const ground_truth = try readFileAlloc(allocator, ground_truth_path, 10 * 1024 * 1024);
+    var files_ok = true;
+    const ground_truth = readFileAlloc(allocator, ground_truth_path, 10 * 1024 * 1024) catch |err| switch (err) {
+        error.FileNotFound => blk: {
+            files_ok = false;
+            break :blk "<file not found>";
+        },
+        else => |e| return e,
+    };
     defer allocator.free(ground_truth);
 
-    const new_input = try readFileAlloc(allocator, new_input_path, 10 * 1024 * 1024);
+    const new_input = readFileAlloc(allocator, new_input_path, 10 * 1024 * 1024) catch |err| switch (err) {
+        error.FileNotFound => blk: {
+            files_ok = false;
+            break :blk "<file not found>";
+        },
+        else => |e| return e,
+    };
     defer allocator.free(new_input);
 
     // Compare full file contents for now. This keeps the snapshot tests simple and
@@ -33,6 +46,9 @@ pub fn main() !u8 {
         error.TestExpectedEqual => return 1,
         else => return err,
     };
+
+    if (!files_ok)
+        return 1;
 
     return 0;
 }

--- a/test/snapshot/footnotes.hdoc
+++ b/test/snapshot/footnotes.hdoc
@@ -1,0 +1,7 @@
+hdoc(version="2.0",lang="en");
+title{Footnotes Demo}
+p{Intro with footnote\footnote{Footnote text} and citation\footnote(kind="citation",key="ref1"){Citation text}.}
+footnotes;
+p{Next section references \footnote(ref="ref1"); and adds another\footnote{Second footnote}.}
+footnotes(kind="citation");
+footnotes;

--- a/test/snapshot/footnotes.html
+++ b/test/snapshot/footnotes.html
@@ -1,0 +1,31 @@
+<header lang="en">
+  <h1>Footnotes Demo</h1>
+</header>
+<p>Intro with footnote<sup class="hdoc-footnote-ref hdoc-footnote"><a href="#hdoc-footnote-1">1</a></sup> and citation<sup class="hdoc-footnote-ref hdoc-citation"><a href="#hdoc-citation-1">1</a></sup>.</p>
+<div class="hdoc-footnotes">
+  <ol class="hdoc-footnote-list hdoc-footnote" start="1">
+    <li id="hdoc-footnote-1">
+      <p>Footnote text</p>
+    </li>
+  </ol>
+  <ol class="hdoc-footnote-list hdoc-citation" start="1">
+    <li id="hdoc-citation-1">
+      <p>Citation text</p>
+    </li>
+  </ol>
+</div>
+<p>Next section references <sup class="hdoc-footnote-ref hdoc-citation"><a href="#hdoc-citation-1">1</a></sup> and adds another<sup class="hdoc-footnote-ref hdoc-footnote"><a href="#hdoc-footnote-2">2</a></sup>.</p>
+<div class="hdoc-footnotes">
+  <ol class="hdoc-footnote-list hdoc-citation" start="1">
+    <li id="hdoc-citation-1">
+      <p>Citation text</p>
+    </li>
+  </ol>
+</div>
+<div class="hdoc-footnotes">
+  <ol class="hdoc-footnote-list hdoc-footnote" start="2">
+    <li id="hdoc-footnote-2">
+      <p>Second footnote</p>
+    </li>
+  </ol>
+</div>

--- a/test/snapshot/footnotes.yaml
+++ b/test/snapshot/footnotes.yaml
@@ -1,0 +1,69 @@
+document:
+  version:
+    major: 2
+    minor: 0
+  lang: "en"
+  title:
+    simple: "Footnotes Demo"
+    full:
+      lang: ""
+      content:
+        - [] "Footnotes Demo"
+  author: null
+  date: null
+  toc:
+    level: h1
+    headings: []
+    children: []
+  contents:
+    - paragraph:
+      lang: ""
+      content:
+        - [] "Intro with footnote"
+        - [] "footnote:footnote:1"
+        - [] " and citation"
+        - [] "footnote:citation:1"
+        - [] "."
+    - footnotes:
+      lang: ""
+      entries:
+        -         index: 1
+        kind: footnote
+        lang: ""
+        content:
+          - [] "Footnote text"
+        -         index: 1
+        kind: citation
+        lang: ""
+        content:
+          - [] "Citation text"
+    - paragraph:
+      lang: ""
+      content:
+        - [] "Next section references "
+        - [] "footnote:citation:1"
+        - [] " and adds another"
+        - [] "footnote:footnote:2"
+        - [] "."
+    - footnotes:
+      lang: ""
+      entries:
+        -         index: 1
+        kind: citation
+        lang: ""
+        content:
+          - [] "Citation text"
+    - footnotes:
+      lang: ""
+      entries:
+        -         index: 2
+        kind: footnote
+        lang: ""
+        content:
+          - [] "Second footnote"
+  ids:
+    - null
+    - null
+    - null
+    - null
+    - null


### PR DESCRIPTION
## Summary
- parse inline footnotes with key/ref/kind validation and marker definitions
- collect pending footnote entries between dumps, warn when pending markers remain without a dump, and render them in dump and HTML outputs
- ensure footnotes blocks reject body content while clearing pending entries by kind
- add regression tests and an HTML5 fixture covering footnote and citation dumping behavior
- add regression coverage for pending markers across multiple dumps

## Testing
- zig build
- zig build test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958529f1c188322bcd0a5d1104b3869)