### PR TITLE
Add conformance tests for headers and images

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -11,18 +11,26 @@ const snapshot_files: []const []const u8 = &.{
 };
 
 const conformance_accept_files: []const []const u8 = &.{
+    "test/conformance/accept/header_and_title_order.hdoc",
+    "test/conformance/accept/image_with_required_path.hdoc",
     "test/conformance/accept/inline_escape.hdoc",
+    "test/conformance/accept/no_title_document.hdoc",
     "test/conformance/accept/title_header_redundant.hdoc",
 };
 
 const conformance_reject_files: []const []const u8 = &.{
-    "test/conformance/reject/string_cr_escape.hdoc",
-    "test/conformance/reject/inline_identifier_dash.hdoc",
-    "test/conformance/reject/heading_sequence.hdoc",
-    "test/conformance/reject/nested_top_level.hdoc",
     "test/conformance/reject/container_children.hdoc",
+    "test/conformance/reject/duplicate_header.hdoc",
+    "test/conformance/reject/hdoc_body_non_empty.hdoc",
+    "test/conformance/reject/heading_sequence.hdoc",
+    "test/conformance/reject/image_missing_path.hdoc",
+    "test/conformance/reject/inline_identifier_dash.hdoc",
+    "test/conformance/reject/missing_header.hdoc",
+    "test/conformance/reject/nested_top_level.hdoc",
     "test/conformance/reject/time_relative_fmt.hdoc",
     "test/conformance/reject/ref_in_heading.hdoc",
+    "test/conformance/reject/string_cr_escape.hdoc",
+    "test/conformance/reject/title_after_content.hdoc",
 };
 
 pub fn build(b: *std.Build) void {

--- a/test/conformance/accept/header_and_title_order.hdoc
+++ b/test/conformance/accept/header_and_title_order.hdoc
@@ -1,0 +1,5 @@
+hdoc(version="2.0", lang="en");
+
+title { Proper Order }
+
+p "Body content"

--- a/test/conformance/accept/header_and_title_order.yaml
+++ b/test/conformance/accept/header_and_title_order.yaml
@@ -1,0 +1,24 @@
+document:
+  version:
+    major: 2
+    minor: 0
+  lang: "en"
+  title:
+    simple: "Proper Order"
+    full:
+      lang: ""
+      content:
+        - [] "Proper Order"
+  author: null
+  date: null
+  toc:
+    level: h1
+    headings: []
+    children: []
+  contents:
+    - paragraph:
+      lang: ""
+      content:
+        - [] "Body content"
+  ids:
+    - null

--- a/test/conformance/accept/image_with_required_path.hdoc
+++ b/test/conformance/accept/image_with_required_path.hdoc
@@ -1,0 +1,3 @@
+hdoc(version="2.0", lang="en");
+
+img(path="media/picture.png", alt="Example figure") { Figure caption }

--- a/test/conformance/accept/image_with_required_path.yaml
+++ b/test/conformance/accept/image_with_required_path.yaml
@@ -1,0 +1,21 @@
+document:
+  version:
+    major: 2
+    minor: 0
+  lang: "en"
+  title: null
+  author: null
+  date: null
+  toc:
+    level: h1
+    headings: []
+    children: []
+  contents:
+    - image:
+      lang: ""
+      alt: "Example figure"
+      path: "media/picture.png"
+      content:
+        - [] "Figure caption"
+  ids:
+    - null

--- a/test/conformance/accept/no_title_document.hdoc
+++ b/test/conformance/accept/no_title_document.hdoc
@@ -1,0 +1,3 @@
+hdoc(version="2.0", lang="en");
+
+p "Untitled body"

--- a/test/conformance/accept/no_title_document.yaml
+++ b/test/conformance/accept/no_title_document.yaml
@@ -1,0 +1,19 @@
+document:
+  version:
+    major: 2
+    minor: 0
+  lang: "en"
+  title: null
+  author: null
+  date: null
+  toc:
+    level: h1
+    headings: []
+    children: []
+  contents:
+    - paragraph:
+      lang: ""
+      content:
+        - [] "Untitled body"
+  ids:
+    - null

--- a/test/conformance/reject/duplicate_header.diag
+++ b/test/conformance/reject/duplicate_header.diag
@@ -1,0 +1,20 @@
+[
+  {
+    "code": {
+      "misplaced_hdoc_header": {}
+    },
+    "location": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  {
+    "code": {
+      "duplicate_hdoc_header": {}
+    },
+    "location": {
+      "line": 3,
+      "column": 1
+    }
+  }
+]

--- a/test/conformance/reject/duplicate_header.hdoc
+++ b/test/conformance/reject/duplicate_header.hdoc
@@ -1,0 +1,5 @@
+hdoc(version="2.0", lang="en");
+
+hdoc(version="2.0", lang="en");
+
+p "Duplicate headers"

--- a/test/conformance/reject/hdoc_body_non_empty.diag
+++ b/test/conformance/reject/hdoc_body_non_empty.diag
@@ -1,0 +1,11 @@
+[
+  {
+    "code": {
+      "non_empty_hdoc_body": {}
+    },
+    "location": {
+      "line": 1,
+      "column": 1
+    }
+  }
+]

--- a/test/conformance/reject/hdoc_body_non_empty.hdoc
+++ b/test/conformance/reject/hdoc_body_non_empty.hdoc
@@ -1,0 +1,1 @@
+hdoc(version="2.0", lang="en") "not empty"

--- a/test/conformance/reject/image_missing_path.diag
+++ b/test/conformance/reject/image_missing_path.diag
@@ -1,0 +1,14 @@
+[
+  {
+    "code": {
+      "missing_attribute": {
+        "type": "img",
+        "name": "path"
+      }
+    },
+    "location": {
+      "line": 3,
+      "column": 1
+    }
+  }
+]

--- a/test/conformance/reject/image_missing_path.hdoc
+++ b/test/conformance/reject/image_missing_path.hdoc
@@ -1,0 +1,3 @@
+hdoc(version="2.0", lang="en");
+
+img { Figure caption }

--- a/test/conformance/reject/missing_header.diag
+++ b/test/conformance/reject/missing_header.diag
@@ -1,0 +1,11 @@
+[
+  {
+    "code": {
+      "missing_hdoc_header": {}
+    },
+    "location": {
+      "line": 1,
+      "column": 1
+    }
+  }
+]

--- a/test/conformance/reject/missing_header.hdoc
+++ b/test/conformance/reject/missing_header.hdoc
@@ -1,0 +1,1 @@
+p "No header present"

--- a/test/conformance/reject/title_after_content.diag
+++ b/test/conformance/reject/title_after_content.diag
@@ -1,0 +1,11 @@
+[
+  {
+    "code": {
+      "misplaced_title_block": {}
+    },
+    "location": {
+      "line": 5,
+      "column": 1
+    }
+  }
+]

--- a/test/conformance/reject/title_after_content.hdoc
+++ b/test/conformance/reject/title_after_content.hdoc
@@ -1,0 +1,5 @@
+hdoc(version="2.0", lang="en");
+
+p "First content"
+
+title { Late Title }


### PR DESCRIPTION
## Summary
- add positive conformance fixtures for header/title ordering, optional titles, and images with relative paths
- add reject cases for missing or invalid headers, misplaced titles, and images without required paths
- register new conformance files in the build script

## Testing
- zig build test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a05ee591c832295d561d586a737fa)