### PR TITLE
Simplify WebAssembly logging and buffer handling

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -41,6 +41,7 @@ pub fn build(b: *std.Build) void {
     // Targets:
     const run_step = b.step("run", "Run the app");
     const test_step = b.step("test", "Run unit tests");
+    const wasm_target = b.resolveTargetQuery(.{ .cpu_arch = .wasm32, .os_tag = .freestanding });
 
     // Build:
     const hyperdoc = b.addModule("hyperdoc", .{
@@ -59,6 +60,20 @@ pub fn build(b: *std.Build) void {
         }),
     });
     b.installArtifact(exe);
+
+    const wasm_exe = b.addExecutable(.{
+        .name = "hyperdoc_wasm",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/wasm.zig"),
+            .target = wasm_target,
+            .optimize = optimize,
+            .single_threaded = true,
+            .imports = &.{
+                .{ .name = "hyperdoc", .module = hyperdoc },
+            },
+        }),
+    });
+    b.installArtifact(wasm_exe);
 
     const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());

--- a/src/playground.html
+++ b/src/playground.html
@@ -1,0 +1,284 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>HyperDoc Playground</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    }
+
+    body {
+      margin: 0;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      background: #f8f9fb;
+    }
+
+    header {
+      padding: 12px 16px;
+      font-size: 18px;
+      font-weight: 600;
+      border-bottom: 1px solid #d8dde6;
+      background: #ffffff;
+    }
+
+    .layout {
+      flex: 1;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+      padding: 12px;
+      box-sizing: border-box;
+    }
+
+    .pane {
+      display: flex;
+      flex-direction: column;
+      border: 1px solid #d8dde6;
+      border-radius: 8px;
+      background: #ffffff;
+      overflow: hidden;
+    }
+
+    .pane-header {
+      padding: 10px 12px;
+      font-weight: 600;
+      border-bottom: 1px solid #e4e7ed;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+    }
+
+    textarea {
+      flex: 1;
+      width: 100%;
+      border: none;
+      padding: 12px;
+      resize: none;
+      font-family: "JetBrains Mono", Consolas, "Courier New", monospace;
+      font-size: 14px;
+      box-sizing: border-box;
+      outline: none;
+    }
+
+    .preview {
+      flex: 1;
+      padding: 12px;
+      overflow: auto;
+      box-sizing: border-box;
+    }
+
+    .diagnostics {
+      list-style: none;
+      margin: 0;
+      padding: 12px;
+      border-top: 1px solid #e4e7ed;
+      max-height: 180px;
+      overflow: auto;
+      display: none;
+      gap: 8px;
+      flex-direction: column;
+      background: #fff6f6;
+    }
+
+    .diagnostics.visible {
+      display: flex;
+    }
+
+    .diagnostics li {
+      margin: 0;
+      padding: 8px 10px;
+      background: #ffe3e3;
+      border: 1px solid #ffc2c2;
+      border-radius: 6px;
+      font-family: "JetBrains Mono", Consolas, "Courier New", monospace;
+      font-size: 13px;
+    }
+
+    .status {
+      font-size: 13px;
+      color: #4a5568;
+    }
+
+    .status.error {
+      color: #c53030;
+      font-weight: 600;
+    }
+
+    .status.ok {
+      color: #2f855a;
+      font-weight: 600;
+    }
+  </style>
+</head>
+<body>
+  <header>HyperDoc Playground</header>
+  <div class="layout">
+    <section class="pane">
+      <div class="pane-header">
+        <span>HyperDoc Source</span>
+        <span class="status" id="left-status">Waiting for WASM…</span>
+      </div>
+      <textarea id="source" aria-label="HyperDoc source"></textarea>
+    </section>
+    <section class="pane">
+      <div class="pane-header">
+        <span>Preview</span>
+        <span class="status" id="render-status"></span>
+      </div>
+      <div class="preview" id="preview"></div>
+      <ul class="diagnostics" id="diagnostics"></ul>
+    </section>
+  </div>
+  <script type="module">
+    const sourceField = document.getElementById("source");
+    const preview = document.getElementById("preview");
+    const diagnosticsList = document.getElementById("diagnostics");
+    const renderStatus = document.getElementById("render-status");
+    const leftStatus = document.getElementById("left-status");
+
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
+    const wasmUrl = "./hyperdoc_wasm.wasm";
+
+    const initialText = `hdoc(version="2.0", lang="en");
+title {
+  HyperDoc Playground
+}
+
+paragraph {
+  Type HyperDoc content on the left to render HTML here.
+}`;
+
+    sourceField.value = initialText;
+
+    function setStatus(text, className) {
+      renderStatus.textContent = text;
+      renderStatus.className = `status ${className ?? ""}`.trim();
+    }
+
+    function setDiagnostics(items) {
+      diagnosticsList.replaceChildren();
+      if (items.length === 0) {
+        diagnosticsList.classList.remove("visible");
+        return;
+      }
+
+      items.forEach((item) => {
+        const li = document.createElement("li");
+        li.textContent = `Line ${item.line}, Column ${item.column}: ${item.message}`;
+        diagnosticsList.append(li);
+      });
+      diagnosticsList.classList.add("visible");
+    }
+
+    async function bootstrap() {
+      try {
+        const logs = {
+          buffer: "",
+          reset() {
+            this.buffer = "";
+          },
+          append(ptr, len, memory) {
+            if (len === 0 || ptr === 0 || !memory) return;
+            const chunk = new Uint8Array(memory.buffer, ptr, len);
+            this.buffer += decoder.decode(chunk);
+          },
+          flush(level) {
+            const msg = this.buffer;
+            this.reset();
+            const method = ["error", "warn", "info", "debug"][level] ?? "log";
+            console[method](msg);
+          },
+        };
+
+        const importObject = {
+          env: {
+            reset_log() {
+              logs.reset();
+            },
+            append_log(ptr, len) {
+              logs.append(ptr, len, wasmMemory);
+            },
+            flush_log(level) {
+              logs.flush(level);
+            },
+          },
+        };
+
+        const response = await fetch(wasmUrl);
+        const bytes = await response.arrayBuffer();
+        const { instance } = await WebAssembly.instantiate(bytes, importObject);
+        const wasm = instance.exports;
+        let wasmMemory = wasm.memory;
+
+        leftStatus.textContent = "WASM ready";
+
+        function getMemory() {
+          wasmMemory = wasm.memory || wasmMemory;
+          return wasmMemory;
+        }
+
+        function process() {
+          const text = sourceField.value;
+          const data = encoder.encode(text);
+          if (!wasm.hdoc_set_document_len(data.length)) {
+            setStatus("Allocation failed", "error");
+            setDiagnostics([]);
+            preview.textContent = "";
+            return;
+          }
+
+          const ptr = wasm.hdoc_document_ptr();
+
+          const memory = getMemory();
+          if (data.length > 0 && memory && ptr !== 0) {
+            new Uint8Array(memory.buffer, ptr, data.length).set(data);
+          }
+
+          const ok = wasm.hdoc_process() !== 0;
+
+          if (ok) {
+            const htmlPtr = wasm.hdoc_html_ptr();
+            const htmlLen = wasm.hdoc_html_len();
+            const htmlBytes = htmlLen === 0 ? new Uint8Array() : new Uint8Array(getMemory().buffer, htmlPtr, htmlLen);
+            preview.innerHTML = decoder.decode(htmlBytes);
+            setStatus("Rendered", "ok");
+            setDiagnostics([]);
+          } else {
+            preview.innerHTML = "";
+            const count = wasm.hdoc_diagnostic_count();
+            const entries = [];
+            for (let i = 0; i < count; i += 1) {
+              const msgPtr = wasm.hdoc_diagnostic_message_ptr(i);
+              const msgLen = wasm.hdoc_diagnostic_message_len(i);
+              const message = msgLen === 0 ? "" : decoder.decode(new Uint8Array(getMemory().buffer, msgPtr, msgLen));
+              entries.push({
+                line: wasm.hdoc_diagnostic_line(i),
+                column: wasm.hdoc_diagnostic_column(i),
+                message,
+              });
+            }
+            setStatus("Diagnostics found", "error");
+            setDiagnostics(entries);
+          }
+        }
+
+        sourceField.addEventListener("input", process);
+        process();
+      } catch (error) {
+        leftStatus.textContent = "Failed to load WASM";
+        setStatus("Unable to start playground", "error");
+        diagnosticsList.classList.add("visible");
+        diagnosticsList.textContent = String(error);
+      }
+    }
+
+    bootstrap();
+  </script>
+</body>
+</html>

--- a/src/wasm.zig
+++ b/src/wasm.zig
@@ -1,0 +1,221 @@
+const std = @import("std");
+const hyperdoc = @import("hyperdoc");
+
+const LogLevel = enum(u8) { err, warn, info, debug };
+
+extern fn reset_log() void;
+extern fn append_log(ptr: [*]const u8, len: usize) void;
+extern fn flush_log(level: LogLevel) void;
+
+const LogWriter = struct {
+    fn appendWrite(self: LogWriter, chunk: []const u8) error{OutOfMemory}!usize {
+        _ = self;
+        append_log(chunk.ptr, chunk.len);
+        return chunk.len;
+    }
+
+    fn writer(self: LogWriter) std.io.GenericWriter(LogWriter, error{OutOfMemory}, appendWrite) {
+        return .{ .context = self };
+    }
+};
+
+fn log_to_host(
+    comptime level: std.log.Level,
+    comptime _scope: @TypeOf(.enum_literal),
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    _ = _scope;
+
+    reset_log();
+
+    const log_writer = LogWriter{};
+    const writer = log_writer.writer();
+    _ = std.fmt.format(writer, format, args) catch {};
+
+    const mapped: LogLevel = switch (level) {
+        .err => .err,
+        .warn => .warn,
+        .info => .info,
+        .debug => .debug,
+    };
+
+    flush_log(mapped);
+}
+
+fn fixedPageSize() usize {
+    return 4096;
+}
+
+fn zeroRandom(buffer: []u8) void {
+    @memset(buffer, 0);
+}
+
+pub const std_options: std.Options = .{
+    .enable_segfault_handler = false,
+    .logFn = log_to_host,
+    .queryPageSize = fixedPageSize,
+    .cryptoRandomSeed = zeroRandom,
+};
+
+const allocator = std.heap.wasm_allocator;
+
+pub fn panic(message: []const u8, stack_trace: ?*std.builtin.StackTrace, ret_addr: ?usize) noreturn {
+    _ = message;
+    _ = stack_trace;
+    _ = ret_addr;
+    @breakpoint();
+    unreachable;
+}
+
+pub fn main() !void {}
+
+const DiagnosticView = struct {
+    line: u32,
+    column: u32,
+    message: []u8,
+};
+
+var document_buffer: std.array_list.Managed(u8) = std.array_list.Managed(u8).init(allocator);
+var html_buffer: std.array_list.Managed(u8) = std.array_list.Managed(u8).init(allocator);
+var diagnostic_views: std.array_list.Managed(DiagnosticView) = std.array_list.Managed(DiagnosticView).init(allocator);
+var diagnostic_text: std.array_list.Managed(u8) = std.array_list.Managed(u8).init(allocator);
+
+const CountingWriter = struct {
+    count: usize = 0,
+
+    fn write(self: *CountingWriter, bytes: []const u8) error{}!usize {
+        self.count += bytes.len;
+        return bytes.len;
+    }
+
+    fn generic(self: *CountingWriter) std.Io.GenericWriter(*CountingWriter, error{}, write) {
+        return .{ .context = self };
+    }
+};
+
+fn capture_diagnostics(source: *hyperdoc.Diagnostics) !void {
+    diagnostic_views.clearRetainingCapacity();
+    diagnostic_text.clearRetainingCapacity();
+
+    if (source.items.items.len == 0) return;
+
+    var total: usize = 0;
+    for (source.items.items) |diag| {
+        var cw: CountingWriter = .{};
+        _ = diag.code.format(cw.generic()) catch {};
+        total += cw.count;
+    }
+
+    diagnostic_text.ensureTotalCapacityPrecise(total) catch return;
+
+    var diag_writer = diagnostic_text.writer();
+    var adapter_buffer: [256]u8 = undefined;
+    var adapter = diag_writer.any().adaptToNewApi(&adapter_buffer);
+
+    for (source.items.items) |diag| {
+        const start = diagnostic_text.items.len;
+        diag.code.format(&adapter.new_interface) catch {
+            adapter.err = error.WriteFailed;
+        };
+        if (adapter.err) |_| return;
+
+        const rendered = diagnostic_text.items[start..];
+        try diagnostic_views.append(.{
+            .line = diag.location.line,
+            .column = diag.location.column,
+            .message = rendered,
+        });
+    }
+}
+
+export fn hdoc_set_document_len(len: usize) bool {
+    document_buffer.clearRetainingCapacity();
+    document_buffer.items.len = 0;
+
+    if (len == 0) return true;
+
+    document_buffer.ensureTotalCapacityPrecise(len) catch return false;
+    document_buffer.items.len = len;
+    return true;
+}
+
+export fn hdoc_document_ptr() [*]u8 {
+    return document_buffer.items.ptr;
+}
+
+export fn hdoc_process() bool {
+    html_buffer.clearRetainingCapacity();
+    diagnostic_views.clearRetainingCapacity();
+    diagnostic_text.clearRetainingCapacity();
+
+    const source: []const u8 = document_buffer.items;
+
+    var diagnostics = hyperdoc.Diagnostics.init(allocator);
+    defer diagnostics.deinit();
+
+    var parsed = hyperdoc.parse(allocator, source, &diagnostics) catch {
+        capture_diagnostics(&diagnostics) catch {};
+        return false;
+    };
+    defer parsed.deinit();
+
+    if (diagnostics.has_error()) {
+        capture_diagnostics(&diagnostics) catch {};
+        return false;
+    }
+
+    var html_writer = html_buffer.writer();
+    var html_adapter_buffer: [256]u8 = undefined;
+    var html_adapter = html_writer.any().adaptToNewApi(&html_adapter_buffer);
+
+    hyperdoc.render.html5(parsed, &html_adapter.new_interface) catch {
+        html_adapter.err = error.WriteFailed;
+    };
+    if (html_adapter.err) |_| {
+        capture_diagnostics(&diagnostics) catch {};
+        return false;
+    }
+
+    capture_diagnostics(&diagnostics) catch {};
+    return true;
+}
+
+export fn hdoc_html_ptr() ?[*]const u8 {
+    if (html_buffer.items.len == 0) return null;
+    return html_buffer.items.ptr;
+}
+
+export fn hdoc_html_len() usize {
+    return html_buffer.items.len;
+}
+
+export fn hdoc_diagnostic_count() usize {
+    return diagnostic_views.items.len;
+}
+
+export fn hdoc_diagnostic_line(index: usize) u32 {
+    if (index >= diagnostic_views.items.len) return 0;
+
+    return diagnostic_views.items[index].line;
+}
+
+export fn hdoc_diagnostic_column(index: usize) u32 {
+    if (index >= diagnostic_views.items.len) return 0;
+
+    return diagnostic_views.items[index].column;
+}
+
+export fn hdoc_diagnostic_message_ptr(index: usize) ?[*]const u8 {
+    if (index >= diagnostic_views.items.len) return null;
+
+    if (diagnostic_views.items[index].message.len == 0) return null;
+
+    return diagnostic_views.items[index].message.ptr;
+}
+
+export fn hdoc_diagnostic_message_len(index: usize) usize {
+    if (index >= diagnostic_views.items.len) return 0;
+
+    return diagnostic_views.items[index].message.len;
+}


### PR DESCRIPTION
## Summary
- stream HTML rendering directly into the shared buffer via the array list writer adapter
- rebuild diagnostic rendering with a counting pass and single allocation while keeping pointer exports stable
- keep host logging wired through reset/append/flush hooks with breakpointing panic for easier debugging

## Testing
- zig build
- zig build test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a0d95894083229a94b3df2a2acf01)